### PR TITLE
Element Parameters: Update to new Structure

### DIFF
--- a/source/element-parameters.md
+++ b/source/element-parameters.md
@@ -2,7 +2,7 @@
 # Element Parameters
 
 Lattice elements parameters are organized into **parameter groups**. 
-All groups are organized as dictionaries (structures).
+All groups are organized as dictionaries (structures) and lists.
 At the top level, there are the groups with names like 
 `MagneticMultipoleP`, `ElectricMultipoleP`, `MetaP`, `AlignmentP`, etc. 
 By convention, group names use upper camel case and it is highly recommended that this convention


### PR DESCRIPTION
Update the Element Parameters page to the new structure of name first, then element as dict inside.

Also clarifies that we can inherit by element parameter group name and that in-element parameter groups have the name of the element they are in.

[See the preview here.](https://pals-project--72.org.readthedocs.build/en/72/element-parameters.html)
