### PR TITLE
Matter Element and MaterialP

### DIFF
--- a/source/lattice-element-kinds.md
+++ b/source/lattice-element-kinds.md
@@ -330,27 +330,6 @@ Element parameter groups associated with this element kind are:
 
 
 %---------------------------------------------------------------------------------------------------
-(s:foil)=
-### Foil Element
-
-A `Foil` element represents a planar sheet of material which can strip electrons from a particle. In
-conjunction, there will be scattering of the particle trajectory as well as an associated energy loss.
-Material that can strip electrons from a particle
-will also cause energy loss and diffusion.
-
-Under Construction...
-
-Element parameter groups associated with this element kind are:
-- [**ApertureP**](#s:aperture.params): Aperture parameters.
-- [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
-- [**FloorP**](#s:floor.params): Floor position and orientation.
-- [**FoilP**](#s:foil.params): Foil parameters.
-- [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
-- [**TrackingP**](#s:tracking.params): Tracking parameters.
-
-
-%---------------------------------------------------------------------------------------------------
 (s:fork)=
 ### Fork Element
 
@@ -486,6 +465,24 @@ Element parameter groups associated with this element kind are:
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 The length of this element is considered to be zero so if `length` is specified, it must be zero.
+
+
+%---------------------------------------------------------------------------------------------------
+(s:matter)=
+## Matter Element
+
+Materials which fully occupy the beamline, like targets, (stripper-)foils, vacuum windows, gas cells or degraders.
+This element can cause energy-loss, angualar and energy straggling, as well as change of charge state or particle type.
+
+Element parameter groups associated with this element kind are:
+- [**ApertureP**](#s:aperture.params): Aperture parameters of the outer (blocking) aperture.
+- [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
+- [**FloorP**](#s:floor.params): Floor position and orientation.
+- [**MetaP**](#s:meta.params): Meta parameters.
+- [**ReferenceP**](#s:ref.params): Reference parameters.
+- [**ReferenceChangeP**](#s:refchange.params): Reference energy change and/or reference time correction.
+- [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**MatterP**](#s:matter.params): Matter parameters.
 
 
 %---------------------------------------------------------------------------------------------------

--- a/source/lattice-element-kinds.md
+++ b/source/lattice-element-kinds.md
@@ -484,7 +484,6 @@ Element parameter groups associated with this element kind are:
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 - [**MatterP**](#s:matter.params): Matter parameters.
 
-
 %---------------------------------------------------------------------------------------------------
 (s:multipole)=
 ### Multipole Element

--- a/source/parameters/aperture.md
+++ b/source/parameters/aperture.md
@@ -16,7 +16,7 @@ ApertureP:
   shape: ELLIPTICAL                # [enum] Aperture shape switch
   location: ENTRANCE_END           # [enum] Aperture location switch
   vertices: []                     # [array] Array of vertex points. See below.
-  material: ""                     # [string] Material of the Aperture
+  material: ""                     # [MaterialP] Material of the Aperture
   thickness: 0                     # [m] Real number
   aperture_shifts_with_body: false # [logical] See below.
   aperture_active: true            # [logical] false implies aperture is not operating.
@@ -125,7 +125,6 @@ The difference between the two lists is simply that lines 2 and 3 are switched a
 ### material
 
 The `material` parameter sets the material of the aperture. 
-Using chemical formulas like `Cu` and `Fe` is the most portable.
 
 ### vertices component
 

--- a/source/parameters/material.md
+++ b/source/parameters/material.md
@@ -14,7 +14,7 @@ ElementP:
 - A:         # [int]    The mass number (equals Z+N)
 - N:         # [int]    The neutron number
 - m:         # [g/mol]  The atomic mass
-```{code} yaml
+```
 
 and compunds by
 
@@ -24,7 +24,7 @@ CompundP:
 - density:   # [g/cm^3] The density of the material
 - elements:  # List of MaterialP
 - ratio:    # List of ratios of the elements
-```{code} yaml
+```
 
 ### Examples
 `MaterialP: "G4_Cu"` or `MaterialP: "G4_STAINLESS-STEEL"` or define a new material.
@@ -37,7 +37,7 @@ MaterialP:
 - Z: 1
 - A: 1
 - m: 2.01
-```{code} yaml
+```
 and deuterated polyethylene (C2H4) can be defined based on the previous definition
 ```{code} yaml
 MaterialP:
@@ -49,6 +49,6 @@ MaterialP:
 - ratio:
   - 2
   - 4
-```{code} yaml
+```
 
 

--- a/source/parameters/material.md
+++ b/source/parameters/material.md
@@ -38,7 +38,7 @@ If density is not given it will be inferred form the densities and mass fraction
 
 
 ### Examples
-`MaterialP: "Cu"` or `MaterialP: "G4_STAINLESS-STEEL"` or define a new material.
+`material: "Cu"` or `material: "G4_STAINLESS-STEEL"` or define a new material.
 
 Liquid deuterium can be defined with the `ElementP` parameters:
 ```{code} yaml

--- a/source/parameters/material.md
+++ b/source/parameters/material.md
@@ -1,0 +1,54 @@
+(s:material.params)=
+## MaterialP:  Definition of materials
+
+The definition of materials is inspired by Geant4's material handling. One can either use the name, which is the symbol of an element (`"G4_Cu"`, `"G4_H"`, ...) or compound (`"G4_STAINLESS-STEEL"`).
+In the future all elements and materials in the [G4 Manual](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Appendix/materialNames.html) will be supported.
+
+Alternatively custom elements can be defined by
+
+```{code} yaml
+ElementP:
+- name:      # [string] The name of the material
+- density:   # [g/cm^3] The density of the material
+- Z:         # [int]    The atomic number
+- A:         # [int]    The mass number (equals Z+N)
+- N:         # [int]    The neutron number
+- m:         # [g/mol]  The atomic mass
+```
+
+and compunds by
+
+```{code} yaml
+CompundP:
+- name:      # [string] The name of the material
+- density:   # [g/cm^3] The density of the material
+- elements:  # List of MaterialP
+- ratio:    # List of ratios of the elements
+```
+
+### Examples
+`MaterialP: "G4_Cu"` or `MaterialP: "G4_STAINLESS-STEEL"` or define a new material.
+
+Liquid deuterium can be defined with the `ElementP` parameters:
+```{code} yaml
+MaterialP:
+- name: "Deuterium(l)"
+- density: 0.16
+- Z: 1
+- A: 1
+- m: 2.01
+```
+and deuterated polyethylene (C2H4) can be defined based on the previous definition
+```{code} yaml
+MaterialP:
+- name: "deutPE"
+- density: 1.05
+- elements:
+  - "G4_C"
+  - "Deuterium(l)"
+- ratio:
+  - 2
+  - 4
+```
+
+

--- a/source/parameters/material.md
+++ b/source/parameters/material.md
@@ -27,7 +27,7 @@ and compounds by
 ```{code} yaml
 CompoundP:
 - name:       # [string] The name of the material
-- density:    # [kg/cm^3] The density of the material
+- density:    # [kg/m^3] The density of the material
 - elements:   # List of MaterialP or CompoundP of which the compound consists
 - ratio:      # List of ratios of the elements
 - mass_ratio: # List of mass-ratios of the elements

--- a/source/parameters/material.md
+++ b/source/parameters/material.md
@@ -9,11 +9,11 @@ Alternatively custom elements can be defined by
 ```{code} yaml
 ElementP:
 - name:      # [string] The name of the material
-- density:   # [g/cm^3] The density of the material
+- density:   # [kg/m^3] The density of the material
 - Z:         # [int]    The atomic number
 - A:         # [int]    The mass number (equals Z+N)
 - N:         # [int]    The neutron number
-- m:         # [g/mol]  The atomic mass
+- m:         # [u]      The atomic mass
 ```
 
 and compunds by
@@ -21,7 +21,7 @@ and compunds by
 ```{code} yaml
 CompundP:
 - name:      # [string] The name of the material
-- density:   # [g/cm^3] The density of the material
+- density:   # [kg/cm^3] The density of the material
 - elements:  # List of MaterialP
 - ratio:    # List of ratios of the elements
 ```
@@ -33,7 +33,7 @@ Liquid deuterium can be defined with the `ElementP` parameters:
 ```{code} yaml
 MaterialP:
 - name: "Deuterium(l)"
-- density: 0.16
+- density: 160
 - Z: 1
 - A: 1
 - m: 2.01
@@ -42,7 +42,7 @@ and deuterated polyethylene (C2H4) can be defined based on the previous definiti
 ```{code} yaml
 MaterialP:
 - name: "deutPE"
-- density: 1.05
+- density: 1050
 - elements:
   - "G4_C"
   - "Deuterium(l)"

--- a/source/parameters/material.md
+++ b/source/parameters/material.md
@@ -1,6 +1,12 @@
 (s:material.params)=
 ## MaterialP:  Definition of materials
 
+```{code} yaml
+MaterialP:
+- state:             # ["solid", "liquid", "gas"]
+- material:          # [CompoundP,ElementP] definiton of the material in terms of compounds or elements.
+```
+
 The definition of materials is inspired by Geant4's material handling. One can either use the name, which is the symbol of an element (`"Cu"`, `"H"`, ...) or compound (`"G4_STAINLESS-STEEL"`).
 In the future all elements and materials in the [G4 Manual](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Appendix/materialNames.html) will be supported, without the `G4_`-prefix for elements.
 

--- a/source/parameters/material.md
+++ b/source/parameters/material.md
@@ -14,7 +14,7 @@ ElementP:
 - A:         # [int]    The mass number (equals Z+N)
 - N:         # [int]    The neutron number
 - m:         # [g/mol]  The atomic mass
-```
+```{code} yaml
 
 and compunds by
 
@@ -24,7 +24,7 @@ CompundP:
 - density:   # [g/cm^3] The density of the material
 - elements:  # List of MaterialP
 - ratio:    # List of ratios of the elements
-```
+```{code} yaml
 
 ### Examples
 `MaterialP: "G4_Cu"` or `MaterialP: "G4_STAINLESS-STEEL"` or define a new material.
@@ -37,7 +37,7 @@ MaterialP:
 - Z: 1
 - A: 1
 - m: 2.01
-```
+```{code} yaml
 and deuterated polyethylene (C2H4) can be defined based on the previous definition
 ```{code} yaml
 MaterialP:
@@ -49,6 +49,6 @@ MaterialP:
 - ratio:
   - 2
   - 4
-```
+```{code} yaml
 
 

--- a/source/parameters/material.md
+++ b/source/parameters/material.md
@@ -1,8 +1,8 @@
 (s:material.params)=
 ## MaterialP:  Definition of materials
 
-The definition of materials is inspired by Geant4's material handling. One can either use the name, which is the symbol of an element (`"G4_Cu"`, `"G4_H"`, ...) or compound (`"G4_STAINLESS-STEEL"`).
-In the future all elements and materials in the [G4 Manual](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Appendix/materialNames.html) will be supported.
+The definition of materials is inspired by Geant4's material handling. One can either use the name, which is the symbol of an element (`"Cu"`, `"H"`, ...) or compound (`"G4_STAINLESS-STEEL"`).
+In the future all elements and materials in the [G4 Manual](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Appendix/materialNames.html) will be supported, without the `G4_`-prefix for elements.
 
 Alternatively custom elements can be defined by
 
@@ -16,22 +16,27 @@ ElementP:
 - m:         # [u]      The atomic mass
 ```
 
-and compunds by
+and compounds by
 
 ```{code} yaml
-CompundP:
-- name:      # [string] The name of the material
-- density:   # [kg/cm^3] The density of the material
-- elements:  # List of MaterialP
-- ratio:    # List of ratios of the elements
+CompoundP:
+- name:       # [string] The name of the material
+- density:    # [kg/cm^3] The density of the material
+- elements:   # List of MaterialP or CompoundP of which the compound consists
+- ratio:      # List of ratios of the elements
+- mass_ratio: # List of mass-ratios of the elements
 ```
 
+`ratio` describes the ratio in terms of atom/molecule count, while `mass_ratio` describes it int terms of mass fractions.
+If density is not given it will be inferred form the densities and mass fractions of the elements.
+
+
 ### Examples
-`MaterialP: "G4_Cu"` or `MaterialP: "G4_STAINLESS-STEEL"` or define a new material.
+`MaterialP: "Cu"` or `MaterialP: "G4_STAINLESS-STEEL"` or define a new material.
 
 Liquid deuterium can be defined with the `ElementP` parameters:
 ```{code} yaml
-MaterialP:
+ElementP:
 - name: "Deuterium(l)"
 - density: 160
 - Z: 1
@@ -40,11 +45,11 @@ MaterialP:
 ```
 and deuterated polyethylene (C2H4) can be defined based on the previous definition
 ```{code} yaml
-MaterialP:
+CompoundP:
 - name: "deutPE"
 - density: 1050
 - elements:
-  - "G4_C"
+  - "C"
   - "Deuterium(l)"
 - ratio:
   - 2

--- a/source/parameters/material.md
+++ b/source/parameters/material.md
@@ -4,59 +4,36 @@
 ```{code} yaml
 MaterialP:
 - state:             # ["solid", "liquid", "gas"]
-- material:          # [CompoundP,ElementP] definiton of the material in terms of compounds or elements.
+- material:          # [CompoundP, string] definition of the material in terms of compounds or named elements.
 ```
 
-The definition of materials is inspired by Geant4's material handling. One can either use the name, which is the symbol of an element (`"Cu"`, `"H"`, ...) or compound (`"G4_STAINLESS-STEEL"`).
-In the future all elements and materials in the [G4 Manual](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Appendix/materialNames.html) will be supported, without the `G4_`-prefix for elements.
+Materials can be accessed primarily by their name. Similar to the openPMD 2.0.0 specification, pure elements names are their symbols of the periodic table, specific isotopes are denoted by a pound symbol `#` followed by the isotopic number followed by an element, e.g.: `#3He` for Helium-3. Pure elements have their natural isotope ratios.
 
-Alternatively custom elements can be defined by
+Mixtures of multiple elements (or isotopes) in specific ratios can be accessed by their name according to Geant4's specifications [G4 Manual](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Appendix/materialNames.html) or defined with a custom `CompoundP` object:
 
-```{code} yaml
-ElementP:
-- name:      # [string] The name of the material
-- density:   # [kg/m^3] The density of the material
-- Z:         # [int]    The atomic number
-- A:         # [int]    The mass number (equals Z+N)
-- N:         # [int]    The neutron number
-- m:         # [u]      The atomic mass
-```
-
-and compounds by
 
 ```{code} yaml
 CompoundP:
 - name:       # [string] The name of the material
 - density:    # [kg/m^3] The density of the material
-- elements:   # List of MaterialP or CompoundP of which the compound consists
+- elements:   # List of ElementP or CompoundP of which the compound consists
 - ratio:      # List of ratios of the elements
 - mass_ratio: # List of mass-ratios of the elements
 ```
-
 `ratio` describes the ratio in terms of atom/molecule count, while `mass_ratio` describes it int terms of mass fractions.
-If density is not given it will be inferred form the densities and mass fractions of the elements.
+If `density` is not given it will be inferred form the densities and mass fractions of the elements.
 
 
 ### Examples
-`material: "Cu"` or `material: "G4_STAINLESS-STEEL"` or define a new material.
+Materials can be the names of the material `material: "Cu"` or `material: "G4_STAINLESS-STEEL"` or defined in place:
 
-Liquid deuterium can be defined with the `ElementP` parameters:
 ```{code} yaml
-ElementP:
-- name: "Deuterium(l)"
-- density: 160
-- Z: 1
-- A: 1
-- m: 2.01
-```
-and deuterated polyethylene (C2H4) can be defined based on the previous definition
-```{code} yaml
-CompoundP:
-- name: "deutPE"
+material:
+- name: "deuterated polyethylene"
 - density: 1050
 - elements:
   - "C"
-  - "Deuterium(l)"
+  - "#2H"
 - ratio:
   - 2
   - 4

--- a/source/parameters/matter.md
+++ b/source/parameters/matter.md
@@ -5,6 +5,6 @@
 MatterP:
 - thickness:         # [m] Thickness in meter
 - area_density:      # [kg/m^2] Density times thickness
-- state:             # ["solid", "liquid", "gas"]
+- MaterialP:          # [MatterP or name] the material
 ```
 Only one of the parameters `thickness` or `area_density` is required.

--- a/source/parameters/matter.md
+++ b/source/parameters/matter.md
@@ -1,0 +1,10 @@
+(s:matter.params)=
+## MatterP:  Definition of materials
+
+```{code} yaml
+MatterP:
+- thickness:         # [m] Thickness in meter
+- area_density:      # [kg/m^2] Density times thickness
+- state:             # ["solid", "liquid", "gas"]
+```
+Only one of the parameters `thickness` or `area_density` is required.

--- a/source/parameters/matter.md
+++ b/source/parameters/matter.md
@@ -5,6 +5,6 @@
 MatterP:
 - thickness:         # [m] Thickness in meter
 - area_density:      # [kg/m^2] Density times thickness
-- MaterialP:          # [MatterP or name] the material
+- MaterialP:         # [MatterP or name] the material
 ```
 Only one of the parameters `thickness` or `area_density` is required.


### PR DESCRIPTION
### Matter
Provide a proposed name for the lattice element.  This can be an abbreviation, and should be at most 1-2 words (e.g., Quadrupole).

## Matter Element (replaces foil)

Materials which fully occupy the beamline, like targets, (stripper-)foils, vacuum windows, gas cells or degraders.
This element can cause energy-loss, angualar and energy straggling, as well as change of charge state or particle type.


## MaterialP:  Definition of materials

The definition of materials is inspired by Geant4's material handling. One can either use the name, which is the symbol of an element (`"G4_Cu"`, `"G4_H"`, ...) or compound (`"G4_STAINLESS-STEEL"`).
In the future all elements and materials in the [G4 Manual](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/Appendix/materialNames.html) will be supported.

Alternatively custom elements can be defined by

```yaml
ElementP:
- name:      # [string] The name of the material
- density:   # [g/cm^3] The density of the material
- Z:         # [int]    The atomic number
- A:         # [int]    The mass number (equals Z+N)
- N:         # [int]    The neutron number
- m:         # [g/mol]  The atomic mass
```

and compound by

```yaml
CompoundP:
- name:      # [string] The name of the material
- density:   # [g/cm^3] The density of the material
- elements:  # List of MaterialP
- ratio:     # List of ratios of the elements
```

### Physical model
I assume a material should be  described precise enough by state, density, thickness and composition.

Note: Due to the stochastic nature of beam-matter interaction, the Taylor-/transfer-map-formalism can only account for the mean average effect.
