### PR TITLE
RTD: Skip PDF

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,5 +18,5 @@ conda:
 
 formats:
   - htmlzip
-  - pdf
   - epub
+#  - pdf


### PR DESCRIPTION
PDF building with latex needs very careful support for ASCII-ish only input right now, because UTF-8 support is not widely available yet in the LaTeX world. To avoid breaking the RTD builds, skip PDF. We primarily use the web page for usage.