### PR TITLE
Open Limits: `null`

### DIFF
--- a/source/introduction.md
+++ b/source/introduction.md
@@ -99,10 +99,11 @@ here `x_limit[1]` and `x_limit[2]` would refer to the first and second values of
 - `false`
 - `null`          # Useful as a default value when neither `true` nor `false` is appropriate.
 
-3. The standard defines the following symbols which can be used in place of a value: 
+3. The standard defines the following symbols which can be used in place of a value:
+- `null`   # Value has not been set: use for open limits, etc.
 - `Inf`    # Infinity
 - `-Inf`   # Negative infinity
-- `NaN`    # Not a number or value has not been set.
+- `NaN`    # Not a number
 
 Note: There is a difference between
 ```{code} yaml

--- a/source/parameters/aperture.md
+++ b/source/parameters/aperture.md
@@ -5,8 +5,8 @@ The `ApertureP` parameter group contains parameters for describing an aperture.
 The components of this group and their defaults are:
 ```{code} yaml
 ApertureP:
-  x_limits: [NaN, NaN]             # [m] Vector of two real numbers
-  y_limits: [NaN, NaN]             # [m] Vector of two real numbers
+  x_limits: [null, null]           # [m] Vector of two real numbers
+  y_limits: [null, null]           # [m] Vector of two real numbers
   shape: ""                        # [string] Aperture shape switch
   location: ENTRANCE_END           # [enum] Aperture location switch
   vertices: []                     # [array] Array of vertex points. See below.
@@ -67,10 +67,10 @@ where
 For a `RECTANGULAR` aperture, a particle is outside of the aperture if any of the following
 four conditions is true:
 ```{code}
-  1) x < x_limits[1] && x_limits[1] != NaN
-  2) x > x_limits[2] && x_limits[2] != NaN
-  3) y < y_limits[1] && y_limits[1] != NaN
-  4) y > y_limits[2] && y_limits[2] != NaN
+  1) x < x_limits[1] && x_limits[1] != null
+  2) x > x_limits[2] && x_limits[2] != null
+  3) y < y_limits[1] && y_limits[1] != null
+  4) y > y_limits[2] && y_limits[2] != null
 ```
 
 ### aperture_shifts_with_body


### PR DESCRIPTION
Close #90 

For open limits and values unset, is technically better to use [the `null` constant](https://yaml.org/spec/1.2.2/#10211-null), which is the semantically correct constant for absence of a value (e.g., translates to `None` in Python). There are also many quirks with comparisons to `NaN` in various programming languages, which can be avoided by using `null`/None, too.