### PR TITLE
Fix Typo in Multipole: Length Int

### DIFF
--- a/source/parameters/electricmultipole.md
+++ b/source/parameters/electricmultipole.md
@@ -31,7 +31,7 @@ emp1:                       # [string] user-defined name
 
 The field and normalized values can be given in terms of the integrated strength.
 Integrated values are specified with the letter 
-`length` appended at the end of the name. Example:
+`L` appended at the end of the name. Example:
 ```{code} yaml
 emp1:
   kind: ElectricMultipoleP

--- a/source/parameters/magneticmultipole.md
+++ b/source/parameters/magneticmultipole.md
@@ -42,7 +42,7 @@ reference momentum.
 
 Furthermore, the field and normalized values can be given in terms of the integrated strength.
 Integrated values are specified with the letter 
-`length` appended at the end of the name. Example:
+`L` appended at the end of the name. Example:
 ```{code} yaml
 MagneticMultipoleP:
   tilt7: 0.7        # Tilt of 7th order multipole


### PR DESCRIPTION
Typo: We mean the letter `L` (not "the letter letter").