### PR TITLE
Integrated MP Component Example

### DIFF
--- a/source/parameters/electricmultipole.md
+++ b/source/parameters/electricmultipole.md
@@ -37,7 +37,7 @@ emp1:
   kind: ElectricMultipoleP
   tilt7: 0.7        # [unitles] Tilt of 7th order multiple
   En3: 27.3         # [unitles] Normal multipole component of order 3
-  En3L: 3.47e1      # [unitles] length integrated normal multipole component of order 3
+  En2L: 3.47e1      # [unitles] length integrated normal multipole component of order 2
 ```
 The length integrated values are related to the non-integrated values via
 ```{code} yaml

--- a/source/parameters/magneticmultipole.md
+++ b/source/parameters/magneticmultipole.md
@@ -47,7 +47,7 @@ Integrated values are specified with the letter
 MagneticMultipoleP:
   tilt7: 0.7        # Tilt of 7th order multipole
   Bn3: 27.3         # Normal multipole component of order 3.
-  Bn3L: 3.47e1      # length integrated normal multipole component of order 3.
+  Bn2L: 3.47e1      # length integrated normal multipole component of order 2.
 ```
 The length integrated values are related to the non-integrated values via
 ```{code} yaml


### PR DESCRIPTION
Improve the example that comes with the multipole
parameter groups to not specify the integrated and non-integrated component of the same order in one
definition.

See https://github.com/pals-project/pals/pull/102#issuecomment-3463378291