### PR TITLE
PALS: Base Structure & Version

### DIFF
--- a/examples/fodo.pals.yaml
+++ b/examples/fodo.pals.yaml
@@ -12,7 +12,7 @@
 PALS:
   version: null  # later, we will put the version of the PALS standard here
 
-  elements:
+  lattices:
     - drift1:
         kind: Drift
         length: 0.25

--- a/source/conventions.md
+++ b/source/conventions.md
@@ -86,7 +86,7 @@ While the standard itself is language agnostic, this document that describes the
 needs to use some syntax and this syntax is based upon YAML.
 
 %---------------------------------------------------------------------------------------------------
-(s:includefiles)=
+(s:palsroot)=
 ## PALS Root Object
 
 The root of the PALS schema is given by this dictionary:
@@ -97,28 +97,6 @@ PALS:
   lattices:
     - ...  # a list of lattice elements and commands
 ```
-
-%---------------------------------------------------------------------------------------------------
-(s:includefiles)=
-## Include Lattice Files
-
-A lattice file can include other lattices (elements and commands) using an include statement.
-
-Example:
-```{code} YAML
-PALS:
-  version: null  # version schema: defined later
-
-  lattices:
-    # the elements and commands of base-lattice.pals.yaml
-    - include: "./base-lattice.pals.yaml"
-    # the elements and commands of extra-lattice.pals.yaml
-    - include: "./base-lattice.pals.yaml"
-    # a list of additional lattice elements and commands
-    - ...
-```
-where the include file names above are examples.
-Includes simply insert the `lattices` block of the `include` file(s).
 
 %---------------------------------------------------------------------------------------------------
 (s:matching)=
@@ -180,6 +158,30 @@ enhances legibility.
 All parameters are optional unless explicitly stated otherwise.
 Optional real or integer parameters have a default value of zero unless otherwise stated.
 Optional string parameters have a default value of blank unless otherwise stated.
+
+%---------------------------------------------------------------------------------------------------
+(s:includefiles)=
+## Include Lattice Files
+
+A lattice file can include other lattices (elements and commands) using an include statement.
+
+Example:
+```{code} YAML
+PALS:
+  # ...
+
+  lattices:
+    # the elements and commands of base-lattice.pals.yaml
+    - include: "./base-lattice.pals.yaml"
+
+    # the elements and commands of extra-lattice.pals.yaml
+    - include: "./base-lattice.pals.yaml"
+
+    # a list of additional lattice elements and commands
+    - ...
+```
+where the include file names above are examples.
+Includes simply insert the `lattices` block of the `include` file(s).
 
 %---------------------------------------------------------------------------------------------------
 (s:names)=


### PR DESCRIPTION
This updates the PALS root structure further, as [discussed in August 2025](https://docs.google.com/document/d/1-v5mxL6MXpjS3_lDU7U2x4-IkV1ETXCKlIiKUTcmS5s/edit?tab=t.0). It also adds a version attribute (schema TBD, e.g., calver or semver) to start on #125.

# Checklist

- [x] update example
- [x] discuss and agree on example update, then
- [ ] can be a later PR: agree on versioning scheme (semver or calver or other) for PALS standard, then
- [x] update standard documentation: [New subsection in _Introduction_](https://pals-project.readthedocs.io/en/latest/conventions.html#)

# Changes

Adds a root level `PALS` key, which helps to group:
- lattice elements (list)
- `version` attribute
- a potential (global) `config` dictionary (later, in brainstorming so far)
- combine with other dictionaries in YAML and JSON and XML files, as needed (for usability)