### PR TITLE
File name suffix convention is recommended but not required.

### DIFF
--- a/source/fileformats.md
+++ b/source/fileformats.md
@@ -2,8 +2,8 @@
 # File Formats
 
 The Particle Accelerator Lattice Standard (PALS) documents objects and their properties.
-For readability, [this standard uses YAML-style](c:conventions) examples, but the PALS schema can be implemented in a variety of file formats.
-
+For readability, [this standard uses YAML-style](c:conventions) examples, 
+but the PALS schema can be implemented in a variety of file formats.
 
 ## File Endings
 
@@ -16,6 +16,9 @@ top-level PALS files (files that contain the root `PALS` node):
 * [XML](https://en.wikipedia.org/wiki/XML): `.pals.xml`
 
 For sub-level [included](#s:includefiles) PALS format files, replace `.pals` with `.subpals`.
+
+Note: Not following the recommendation may lead to, for example, reader/visualization tools 
+not auto discovering the file as PALS, which can create friction for users.
 
 ## Schema Files
 

--- a/source/fileformats.md
+++ b/source/fileformats.md
@@ -7,15 +7,15 @@ For readability, [this standard uses YAML-style](c:conventions) examples, but th
 
 ## File Endings
 
-The following self-describing file suffixes shall be used for top-level PALS files (files that 
-contain the root `PALS` node):
+It is highly recommended that the following self-describing file suffixes be used for 
+top-level PALS files (files that contain the root `PALS` node):
 
 * [YAML](https://yaml.org): `.pals.yaml`
 * [JSON](https://www.json.org/json-en.html): `.pals.json`
 * [TOML](https://toml.io): `.pals.toml`
 * [XML](https://en.wikipedia.org/wiki/XML): `.pals.xml`
 
-For sub-level [included](#s:includefiles) PALS format files, replace `.pals` with `.subpals` .
+For sub-level [included](#s:includefiles) PALS format files, replace `.pals` with `.subpals`.
 
 ## Schema Files
 


### PR DESCRIPTION
It is highly unusual for file name suffixes to be mandated. PALS should not be an exception and the choice should be left up to the User.