### PR TITLE
InitialParticleP renamed to ParticleP and added spin.

### DIFF
--- a/source/element-parameter-groups.md
+++ b/source/element-parameter-groups.md
@@ -36,13 +36,13 @@ See the [Element Parameters](#s:ele.params) section for documentation on element
 ```{include} parameters/girder.md
 ```
 
-```{include} parameters/initialparticle.md
-```
-
 ```{include} parameters/magneticmultipole.md
 ```
 
 ```{include} parameters/meta.md
+```
+
+```{include} parameters/particle.md
 ```
 
 ```{include} parameters/patch.md

--- a/source/element-parameters.md
+++ b/source/element-parameters.md
@@ -138,13 +138,13 @@ element-by-element.
 ```{include} parameters/girder.md
 ```
 
-```{include} parameters/initialparticle.md
-```
-
 ```{include} parameters/magneticmultipole.md
 ```
 
 ```{include} parameters/meta.md
+```
+
+```{include} parameters/particle.md
 ```
 
 ```{include} parameters/patch.md

--- a/source/parameters/particle.md
+++ b/source/parameters/particle.md
@@ -15,7 +15,7 @@ ParticleP:                    # <> denotes average over distribution
   pz:            0            # <pz> pz phase space component
   spin_x         0            # <Sx> Spin x-component
   spin_y         0            # <Sy> Spin y-component
-  spin_z         0            # <Xz> Spin z-component
+  spin_z         0            # <Sz> Spin z-component
   sigma_xx:      null         # <x^2>
   sigma_pxpx:    null         # <px^2>
   sigma_yy:      null         # <y^2>

--- a/source/parameters/particle.md
+++ b/source/parameters/particle.md
@@ -1,19 +1,21 @@
 %---------------------------------------------------------------------------------------------------
-(s:init.particle.params)=
-## InitialParticleP: Initial Particle Coordinates Parameters
+(s:particle.params)=
+## ParticleP: Particle Coordinates Parameters
 
-The `InitialParticleP` parameter group contains parameters for describing the 
-initial beam particle distribution based on its first two moments.
+The `ParticleP` parameter group contains parameters for describing single particle coordinates
+or a beam particle distribution that is Gaussian distributed.
 The components of this group are:
 ```{code} yaml
-InitialParticleP:
-  distribution_type: ""    # [string] name of initial distribution type
-  x_off:         null         # <x>, <> denotes average over distribution
-  px_off:        null         # <px>
-  y_off:         null         # <y>
-  py_off:        null         # <py>
-  z_off:         null         # <z>
-  pz_off:        null         # <pz>
+ParticleP:                    # <> denotes average over distribution
+  x:             0            # <x>  x  phase space component
+  px:            0            # <px> px phase space component
+  y:             0            # <y>  y  phase space component
+  py:            0            # <py> py phase space component
+  z:             0            # <z>  z  phase space component
+  pz:            0            # <pz> pz phase space component
+  spin_x         0            # <Sx> Spin x-component
+  spin_y         0            # <Sy> Spin y-component
+  spin_z         0            # <Xz> Spin z-component
   sigma_xx:      null         # <x^2>
   sigma_pxpx:    null         # <px^2>
   sigma_yy:      null         # <y^2>
@@ -36,4 +38,4 @@ InitialParticleP:
   sigma_pypz:    null         # <py*pz>
   sigma_zpz:     null         # <z*pz>
 ```
-
+When describing a single particle, the `sigma` parameters are not relavent. 

--- a/source/parameters/particle.md
+++ b/source/parameters/particle.md
@@ -38,4 +38,4 @@ ParticleP:                    # <> denotes average over distribution
   sigma_pypz:    null         # <py*pz>
   sigma_zpz:     null         # <z*pz>
 ```
-When describing a single particle, the `sigma` parameters are not relavent. 
+When describing a single particle, the `sigma` parameters are not relevant. 

--- a/source/parameters/particle.md
+++ b/source/parameters/particle.md
@@ -17,25 +17,25 @@ ParticleP:                    # <> denotes average over distribution
   spin_y         0            # <Sy> Spin y-component
   spin_z         0            # <Sz> Spin z-component
   sigma_xx:      null         # <x^2>
-  sigma_pxpx:    null         # <px^2>
-  sigma_yy:      null         # <y^2>
-  sigma_pypy:    null         # <py^2>
-  sigma_zz:      null         # <z^2>
-  sigma_pzpz:    null         # <pz^2>
   sigma_xpx:     null         # <x*px> 
   sigma_xy:      null         # <x*y> 
   sigma_xpy:     null         # <x*py> 
   sigma_xz:      null         # <x*z> 
   sigma_xpz:     null         # <x*pz> 
+  sigma_pxpx:    null         # <px^2>
   sigma_pxy:     null         # <px*y> 
   sigma_pxpy:    null         # <px*py> 
   sigma_pxz:     null         # <px*z> 
   sigma_pxpz:    null         # <px*pz> 
+  sigma_yy:      null         # <y^2>
   sigma_ypy:     null         # <y*py>
   sigma_yz:      null         # <y*z>
   sigma_ypz:     null         # <y*pz>
+  sigma_pypy:    null         # <py^2>
   sigma_pyz:     null         # <py*z>
   sigma_pypz:    null         # <py*pz>
+  sigma_zz:      null         # <z^2>
   sigma_zpz:     null         # <z*pz>
+  sigma_pzpz:    null         # <pz^2>
 ```
 When describing a single particle, the `sigma` parameters are not relevant. 


### PR DESCRIPTION
- `InitialParticleP` renamed to `ParticleP` since this parameter group can be used for more than initialization.
- Removed `distribution_type` since it was not well defined. If someone has a suggestion as to what values to use with this then it can be reinstated.
- Added `spin_x/y/z`
