### PR TITLE
Proposal: An Ordered list w/ unique keys can be used in place of a unordered dictionary

### DIFF
--- a/source/conventions.md
+++ b/source/conventions.md
@@ -53,8 +53,11 @@ this_list:
       key4: value4
 ```
 
+In a lattice file, an ordered list of key-value pairs can always be used in place of a dictionary
+with the restriction that no duplicate keys can be present in the list.
+
 ```{note}
-   Developer note:
+   Code Developer note:
    PALS dictionaries should, when possible, implement a dictionary that preserves insertion order.
 
    While not strictly necessary, this helps with human readability:

--- a/source/conventions.md
+++ b/source/conventions.md
@@ -57,7 +57,7 @@ In a lattice file, an ordered list of key-value pairs can always be used in plac
 with the restriction that no duplicate keys can be present in the list. 
 For example, the above dictionary written as a list would look like:
 ```{code} yaml
-was_a_dictionary_now_a_list:
+this_dictionary_expressed_as_list:
   - key1: value1
   - key2: value2
   - key3: value3

--- a/source/conventions.md
+++ b/source/conventions.md
@@ -54,7 +54,16 @@ this_list:
 ```
 
 In a lattice file, an ordered list of key-value pairs can always be used in place of a dictionary
-with the restriction that no duplicate keys can be present in the list.
+with the restriction that no duplicate keys can be present in the list. 
+For example, the above dictionary written as a list would look like:
+```{code} yaml
+this_dictionary:
+  - key1: value1
+  - key2: value2
+  - key3: value3
+```
+The reverse -- using a dictionary in place of a list -- in general 
+is not allowed since order may be important and lists may have duplicate entries.
 
 ```{note}
    Code Developer note:

--- a/source/conventions.md
+++ b/source/conventions.md
@@ -57,7 +57,7 @@ In a lattice file, an ordered list of key-value pairs can always be used in plac
 with the restriction that no duplicate keys can be present in the list. 
 For example, the above dictionary written as a list would look like:
 ```{code} yaml
-this_dictionary:
+was_a_dictionary_now_a_list:
   - key1: value1
   - key2: value2
   - key3: value3


### PR DESCRIPTION
Clarified that ordered list with unique keys can be used in place of a unordered dictionary.

Rationale: A PALS parser may not always be able to preserve insertion order when it reads in a dict. And it is sometimes desirable to preserve the order. In particular, the [C++ parser being developed](https://github.com/pals-project/pals-cpp) does not have this capability since it uses an external parsing library that does not have this feature. (*)

Correction added by @ax3l: that premise (*) is wrong. The currently picked library (and many other C++ libs for YAML, JSON, etc.) do in fact support preservation of insertion order. This is a [bug in pals-cpp](https://github.com/pals-project/pals-cpp/issues/18) (and [here is the fix](https://github.com/pals-project/pals-cpp/pull/19)); it is not a library issue and not a fundamental limitation.