### PR TITLE
Remove XML from example file formats

### DIFF
--- a/source/fileformats.md
+++ b/source/fileformats.md
@@ -13,7 +13,6 @@ top-level PALS files (files that contain the root `PALS` node):
 * [YAML](https://yaml.org): `.pals.yaml`
 * [JSON](https://www.json.org/json-en.html): `.pals.json`
 * [TOML](https://toml.io): `.pals.toml`
-* [XML](https://en.wikipedia.org/wiki/XML): `.pals.xml`
 
 For sub-level [included](#s:includefiles) PALS format files, replace `.pals` with `.subpals`.
 


### PR DESCRIPTION
I added this in a quick PR earlier on and would like to revise:

## Motivation

XML is not currently used by any known PALS implementation. Listing it may set an expectation that tooling must support it, adding maintenance scope without demonstrated need.

## Change

Remove `.pals.xml` from the recommended file suffixes, which is the only mention of XML.

## Path back

Since the PALS schema is format-agnostic, XML support can be reintroduced if community demand arises and no spec changes are needed. One would need to define though the details of what conventions, attributes, type maps, etc. to reserve in XML, which is extra work not needed just yet.