### PR TITLE
Revamped reference energy/time/species adjustments.

### DIFF
--- a/source/element-kinds.md
+++ b/source/element-kinds.md
@@ -213,21 +213,6 @@ q01w:
 ```
 
 %---------------------------------------------------------------------------------------------------
-(s:reference.change)=
-### ReferenceChange Element
-
-A `ReferenceChange` element is used to adjust reference parameters at any location in a branch.
-These adjusted reference parameters will then be used to calculate the reference parameters for
-the downstream elements of the `ReferenceChange` element.
-
-Element parameter groups associated with this element kind are:
-- [**FloorP**](#s:floor.params): Floor position and orientation.
-- [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference parameters adjustments.
-- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
-- [**TrackingP**](#s:tracking.params): Tracking parameters.
-
-%---------------------------------------------------------------------------------------------------
 (s:rfcavity)=
 ### RFCavity Element
 
@@ -673,6 +658,22 @@ Element parameter groups associated with this element kind are:
 
 Important: By convention, the energy shift is applied after a particle reaches the exit face.
 This matters due to the dependence of the reference velocity on the the reference energy.
+
+
+%---------------------------------------------------------------------------------------------------
+(s:reference.change)=
+### ReferenceChange Element
+
+A `ReferenceChange` element is used to adjust reference parameters at any location in a branch.
+These adjusted reference parameters will then be used to calculate the reference parameters for
+the downstream elements of the `ReferenceChange` element.
+
+Element parameter groups associated with this element kind are:
+- [**FloorP**](#s:floor.params): Floor position and orientation.
+- [**MetaP**](#s:meta.params): Meta parameters.
+- [**ReferenceChangeP**](#s:ref.change.params): Reference parameters adjustments.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
+- [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 
 %---------------------------------------------------------------------------------------------------

--- a/source/element-kinds.md
+++ b/source/element-kinds.md
@@ -24,8 +24,7 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 Example:
@@ -53,8 +52,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 `RBend` and `SBend` elements are parameterized exactly the same way by the `BendP` parameter group. 
@@ -85,8 +83,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 Example:
@@ -110,8 +107,7 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 Example:
@@ -140,8 +136,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 
@@ -159,8 +154,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 
@@ -179,8 +173,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 Example:
@@ -196,7 +189,7 @@ oct01w:
 (s:quadrupole)=
 ### Quadrupole Element
 
-A `quadrupole` is an element whose major field has a linear field dependence .with transverse offset.
+A `Quadrupole` is an element whose major field has a linear field dependence .with transverse offset.
 Both electric and magnetic fields can be defined and the field is not restricted to be linear.
 In terms of functionality, a `quadrupole` is equivalent to a [`Multipole`](#s:multipole) element
 
@@ -207,8 +200,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 Example:
@@ -221,10 +213,25 @@ q01w:
 ```
 
 %---------------------------------------------------------------------------------------------------
+(s:reference.change)=
+### ReferenceChange Element
+
+A `ReferenceChange` element is used to adjust reference parameters at any location in a branch.
+These adjusted reference parameters will then be used to calculate the reference parameters for
+the downstream elements of the `ReferenceChange` element.
+
+Element parameter groups associated with this element kind are:
+- [**FloorP**](#s:floor.params): Floor position and orientation.
+- [**MetaP**](#s:meta.params): Meta parameters.
+- [**ReferenceChangeP**](#s:ref.change.params): Reference parameters adjustments.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
+- [**TrackingP**](#s:tracking.params): Tracking parameters.
+
+%---------------------------------------------------------------------------------------------------
 (s:rfcavity)=
 ### RFCavity Element
 
-An RFCavity element represents an RF cavity that accelerates or decelerates, and focuses or defocuses, a charged particle beam longitudinally and transversely using RF fields.
+An `RFCavity` element represents an RF cavity that accelerates or decelerates, and focuses or defocuses, a charged particle beam longitudinally and transversely using RF fields.
 
 Under Construction...
 
@@ -235,8 +242,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**RFP**](#s:rf.params): RF parameters.
 - [**SolenoidP**](#s:solenoid.params): Solenoid field.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
@@ -260,8 +266,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 Example:
@@ -288,8 +293,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**SolenoidP**](#s:solenoid.params): Solenoid field.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
@@ -317,8 +321,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 
@@ -343,8 +346,7 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 Example:
@@ -384,15 +386,13 @@ Under Construction...
 Element parameter groups associated with this element kind are:
 - [**ApertureP**](#s:aperture.params): Aperture parameters.
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
+- [**ConverterP**](#s:converter.params): Converter parameters.
 - [**ElectricMultipoleP**](#s:elec.mult.params): Electric multipoles
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
-
-The length of this element is considered to be zero so if `length` is specified, it must be zero.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -410,8 +410,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 
@@ -430,12 +429,10 @@ Element parameter groups associated with this element kind are:
 - [**ApertureP**](#s:aperture.params): Aperture parameters.
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
+- [**FoilP**](#s:foil.params): Foil parameters.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
-
-The length of this element is considered to be zero so if `length` is specified, it must be zero.
 
 
 %---------------------------------------------------------------------------------------------------                      
@@ -454,14 +451,11 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 
-
 %---------------------------------------------------------------------------------------------------
----
 (s:instrumentation)=
 ## Instrumentation and Diagnostics
 
@@ -483,8 +477,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 
@@ -510,8 +503,7 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 The length of this element is considered to be zero so if `length` is specified, it must be zero.
@@ -532,8 +524,7 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TaylorP**](#s:taylor.params): Orbital and spin Taylor map.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
@@ -561,7 +552,7 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 The length of this element is considered to be zero so if `length` is specified, it must be zero.
@@ -595,7 +586,7 @@ Also see [`patch`](#s:patch) and [`fiducial`](#s:fiducial) elements.
 Element parameter groups associated with this element kind are:
 - [**FloorShiftP**](#s:floor.shift.params): Floor shift parameters.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -616,8 +607,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**ForkP**](#s:fork.params): Required. Fork element parameters.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 
@@ -635,7 +625,7 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 
 The `length` of this element must be zero.
 
@@ -678,8 +668,7 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
 - [**PatchP**](#s:meta.params): Exit coordinates with respect to entrance coordinates.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 Important: By convention, the energy shift is applied after a particle reaches the exit face.
@@ -720,8 +709,7 @@ Element parameter groups associated with this element kind are:
 - **elements**: A list of contained element kinds.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
-- [**ReferenceP**](#s:ref.params): Reference parameters.
-- [**ReferenceChangeP**](#s:ref.change.params): Reference energy change and/or reference time correction.
+- [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
 
 For each element contained in the `UnionEle`, the nominal position of the contained element is

--- a/source/element-parameter-groups.md
+++ b/source/element-parameter-groups.md
@@ -21,6 +21,9 @@ See the [Element Parameters](#s:ele.params) section for documentation on element
 ```{include} parameters/bodyshift.md
 ```
 
+```{include} parameters/converter.md
+```
+
 ```{include} parameters/electricmultipole.md
 ```
 
@@ -28,6 +31,9 @@ See the [Element Parameters](#s:ele.params) section for documentation on element
 ```
 
 ```{include} parameters/floorshift.md
+```
+
+```{include} parameters/foil.md
 ```
 
 ```{include} parameters/fork.md
@@ -58,6 +64,9 @@ See the [Element Parameters](#s:ele.params) section for documentation on element
 ```
 
 ```{include} parameters/solenoid.md
+```
+
+```{include} parameters/taylor.md
 ```
 
 ```{include} parameters/tracking.md

--- a/source/parameters/converter.md
+++ b/source/parameters/converter.md
@@ -1,0 +1,16 @@
+(s:converter.params)=
+## ConverterP: converter Element Parameters
+
+The `ConverterP` parameter group contains parameters for describing `Converter` elements.
+
+The components of this group are:
+```{code} yaml
+ConverterP:
+  species_out:      # [species] Species produced.
+  E_tot_ref_out     # [eV] Output (downstream) reference energy
+```
+
+The `species_out` parameter gives the species produced. This will be the reference species 
+of the element downstream to the `Converter`.
+
+In Construction...

--- a/source/parameters/foil.md
+++ b/source/parameters/foil.md
@@ -1,0 +1,15 @@
+(s:foil.params)=
+## FoilP: Foil Element Parameters
+
+The `FoilP` parameter group contains parameters for describing foil elements.
+
+The components of this group are:
+```{code} yaml
+FoilP:
+  dE_ref      # [eV] Reference energy change.
+```
+
+The reference energy at the downstream end of the `Foil` element will be `E_tot_ref + dE_ref`
+where `E_tot_ref` is the upstream reference energy.
+
+In Construction...

--- a/source/parameters/reference.md
+++ b/source/parameters/reference.md
@@ -2,7 +2,7 @@
 ## ReferenceP: Reference Parameters
 
 The `ReferenceP` parameter group contains parameters for describing the reference energy,
-species, and time. 
+species, and time at the upstream end of the element. 
 The components of this group and their defaults are:
 ```{code} yaml
 ReferenceP:
@@ -10,27 +10,37 @@ ReferenceP:
   pc_ref: 0         # [momentum*c] Reference momentum times speed of light
   E_tot_ref: 0      # [eV] Reference total energy
   time_ref: 0       # [s] Reference time
-  location: ""      # [string] Where reference parameters are evaluated
 ```
 
-The `location` component records where the reference parameters are evaluated at.
-Possible values are
-```{code} yaml
-  location: UPSTREAM_END    # Upstream end of the element
-```
-and
-```{code} yaml
-  location: DOWNSTREAM_END  # Downstream end of the element
-```
 Except for `time_ref`, the reference parameters are generally the same at the
 upstream and downstream ends of the element. However, there are exceptions.
 For example, the upstream and downstream `species_ref` for a `Foil` element 
-will generally be different. And the reference energy will change if the
-`dE_ref` component of the [`ReferenceChangeP`](#s:ref.change.params) group is nonzero.
-See the [`ReferenceChangeP`](#s:ref.change.params) for details as how the reference
-energy and time is computed.
+will generally be different. And the reference energy will change if the element has a
+`dE_ref` as in an `RFCavity` element.
 
 For a `BeginningEle` element, parameters of this group are user settable.
 For all other element kinds, the parameters of this
 group are calculated (output parameters) and are not user settable. 
-To shift reference parameters, use the ReferenceChangeP parameter group.
+The reference parameters at the upstream end of any non-`BeginningEle` element will be the 
+same as the reference parameters at the downstream end of the previous element.
+To adjust reference parameters at any point in a lattice branch, use the `ReferenceChange` element.
+
+The downstream reference time is calculated via
+```{code} yaml
+time_ref(downstream) = time_ref(upstream) + transit_time
+```
+where `transit_time` is the time to transit the element assuming a straight line trajectory
+and a linear energy change throughout the element. The formula
+for the transit time is
+```{code} yaml
+transit_time = length * (E_tot_ref(upstream) + E_tot_ref(downstream)) / 
+                            (c * (pc_ref(upstream) + pc_ref(downstream)))
+```
+where `length` is the length of the element and `c` is the speed of light.
+For elements where there is no energy
+change (no associated `dE_ref` element parameter), the transit time calculation simplifies to
+```{code} yaml
+transit_time = length / (beta_ref * c)
+```
+where `beta_ref` is the normalized particle reference velocity.
+

--- a/source/parameters/referencechange.md
+++ b/source/parameters/referencechange.md
@@ -1,52 +1,25 @@
 (s:ref.change.params)=
-## ReferenceChangeP: Change in Reference Parameters
+## ReferenceChangeP: Adjustment of Reference Parameters
 
-The `ReferenceChangeP` parameter group contains parameters for describing how the reference energy,
-and time deviate from the nominal values from one end of an element to the other end.
+The `ReferenceChangeP` parameter group can be used to adjust reference parameters.
+For example, it is often convenient to adjust the reference time after a `Wiggler`
+element to account for the extra transit time due to particle oscillations.
+
 The components of this group are:
 ```{code} yaml
 ReferenceChangeP:
-  extra_dtime_ref: 0   # [sec] Reference time deviation from nominal.
-  dE_ref: null         # [eV] Change in reference energy.
-  E_tot_ref: null      # [eV] Reference energy at exit end.
-  species_ref: null    # [species] Species at exit end.
+  dtime_ref: null      # [sec] Reference time adjustment
+  dE_ref: null         # [eV] Reference energy adjustment.
+  dpc_ref: null        # [eV] Reference momentum adjustment.
+  time_ref: null       # [eV] Set reference time.
+  E_tot_ref: null      # [eV] Set reference energy.
+  pc_ref: null         # [eV] Set reference momentum.
+  species_ref: null    # [species] Set reference species.
 ```
-Note: The reference energy, time, and species are stored in the [`ReferenceP`](#s:ref.params) group.
 
-The exit end reference energy is calculated in one of two ways. 
-If `E_tot_ref` is set, that is the exit reference energy.
-If `dE_ref` is set, the exit reference energy is calculated from the entrance value via
-```{code} yaml
-E_tot_ref(exit) = E_tot_ref(entrance) + dE_ref
-```
-Notice that this formula is formulated with respect to the entrance and exit ends of the
-element as opposed to the upstream and downstream ends. This is done so that reversing
-an element longitudinally reverses the change in reference energy.
-It is not permitted to set both `E_tot_ref` and `dE_ref`.
-
-The downstream reference time is calculated via
-```{code} yaml
-time_ref(downstream) = time_ref(upstream) + transit_time + extra_dtime_ref
-```
-where `transit_time` is the time to transit the element assuming a straight line trajectory
-and a linear energy change throughout the element. The formula
-for the transit time is
-```{code} yaml
-transit_time = length * (E_tot_ref(upstream) + E_tot_ref(downstream)) / 
-                            (c * (pc_ref(upstream) + pc_ref(downstream)))
-```
-where `length` is the length of the element and `c` is the speed of light.
-For elements where there is no energy
-change (`dE_ref` = 0), the transit time calculation simplifies to
-```{code} yaml
-transit_time = length / (beta_ref * c)
-```
-where `beta_ref` is the normalized particle velocity.
-
-The `species_ref` parameter can be used to set the outgoing reference species. This is
-typically used in elements in things like `Foil` elements where the outgoing particles of interest
-are not the same as the incoming. If `species_ref` is set, the transit time calculation uses
-the species set by `species_ref`. 
+Adjustments are only made if there are non-`null` parameters. Only one of `dE_ref`,
+`dpc_ref`, `E_tot_ref`, and `pc_ref` may be present. 
+Similarly, only one of  `dtime_ref` and `time_ref` may be present.
 
 The `extra_dtime_ref` parameter in the above is ment as a correction to take into account
 for particle motion that is not straight or acceleration that is not linear in energy. For example,

--- a/source/parameters/rf.md
+++ b/source/parameters/rf.md
@@ -14,6 +14,7 @@ RFP:
   num_cells: null               # [-] Number of cavity cells
   zero_phase: ACCELERATING      # [enum] Sets what phase = 0 means.
   L_active: L                   # [m] Active acceleration length.
+  dE_ref: 0                     # [eV] Change in reference energy.
 ```
 Either `frequency` or `harmon` should be set but not both. The 
 relationship between the two is `frequency = harmon / t1_ref` where
@@ -45,3 +46,6 @@ The RF phase `phase_RF`, in units of `rad/2pi`, at time `t` will be
 phase_RF = t*frequency + phase + phi0
 ```
 where `phi0` is a phase determined by the setting of `zero_phase`. 
+
+The reference energy at the downstream end of the RF element will be `E_tot_ref + dE_ref`
+where `E_tot_ref` is the upstream reference energy.


### PR DESCRIPTION
Rational: Reference adjustments should not be part of "regular" elements (like quadrupoles, etc.) since the fact that such an adjustment is being used is obscured. With the current PR, adjustments are confined to be in a specific `ReferenceChange` element.