### PR TITLE
Rename 'Lattice' to 'Language' in Sphinx project configuration

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'Particle Accelerator Lattice Standard (PALS)'
+project = 'Particle Accelerator Language Standard (PALS)'
 copyright = '2025, under CC-BY 4.0 License'
 author = 'Jean-Luc Vay, David Sagan, Chad Mitchell, Axel Huebl, David Bruhwihler, Christopher Mayes, Eric Stern, Daniel Winklehner, Michael Ehrlichman, Martin Berz, Giovanni Iadarola, Ji Qiang, Edoardo Zoni, Laurent Deniau, et al.'
 


### PR DESCRIPTION
I looked at the new documentation after merging the latest PR and noticed that we still have "Lattice" instead of "Language" in the project title set in the Sphinx configuration file (top left corner in the screenshot).

<img width="2479" height="1235" alt="Screenshot from 2026-06-30 10-49-40" src="https://github.com/user-attachments/assets/84142287-3b01-4b08-aab0-2c5fd0241991" />
