### PR TITLE
Controller

### DIFF
--- a/source/fundamentals.md
+++ b/source/fundamentals.md
@@ -229,6 +229,10 @@ For constants that only have a value, an alternative compact form has the syntax
       ...
 ```
 
+Circular definitions are not allowed. For example, if constant `a` is defined in terms of constant
+`b`, and constant `b` is defined in terms of constant `c`, then the expression for `c` cannot
+involve `a` nor `b`.
+
 %---------------------------------------------------------------------------------------------------
 (s:functions)=
 ## Functions
@@ -263,3 +267,16 @@ mass_of(A)               # Mass of particle A
 charge_of(A)             # Charge, in units of the elementary charge, of particle A 
 anomalous_moment_of(A)   # Anomalous magnetic moment of particle A
 ```
+
+%---------------------------------------------------------------------------------------------------
+(s:expressions)=
+## Mathematical Expressions
+
+Mathematical expressions can be used in place of any real value.
+The expressions can involve the functions listed in the [Functions](#s:functions) section,
+constants as listed in the [Constants](#s:constants) section, and [user defined constants](#s:constants).
+[Lattice element parameter](#s:parameter.matching) values can also be incorporated.
+
+
+
+

--- a/source/fundamentals.md
+++ b/source/fundamentals.md
@@ -277,6 +277,3 @@ The expressions can involve the functions listed in the [Functions](#s:functions
 constants as listed in the [Constants](#s:constants) section, and [user defined constants](#s:constants).
 [Lattice element parameter](#s:parameter.matching) values can also be incorporated.
 
-
-
-

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -58,12 +58,12 @@ facility:
         cur1: 0.023
         cur2: cur1 / c_light
         ...
-      controls:                        
+      controls: 
         - parameter: Qa.*>MagneticMultipoleP.Ks2L  # Parameter control specification.
           expression: 0.075*sin(cur1) + 0.3*cur2
         - parameter: ...                           # Another specification
           expression: ...           
-       ...
+        ...
 ```
 In this example, a controller called `ps27` has two variables used to control parameters called
 `cur1` and `cur2`. Initial values can be set for variables. The default value of a variable is zero.
@@ -71,12 +71,9 @@ The parameters controlled are set by the `controls` component. Each entry has a
 `parameter` component giving the [regular expression](#s:parameter.matching) to 
 match parameters to and an `expression` component that gives the arithmetic expression
 used in setting the parameters matched to. 
-In the above example, the first `controls` group will match to the `Ks2L` 
-component of all elements whose name begins with `Qa`. 
-
-
- In this example, that expression is
-`0.075*sin(cur1) + 0.3*cur2`.
+In the above example, the first `controls` entry will match to the `Ks2L` 
+component of all elements whose name begins with `Qa`, and the associated expression
+is `0.075*sin(cur1) + 0.3*cur2`.
 
 Controllers can control the variables of other controllers. The syntax for a controller 
 variable is:
@@ -138,7 +135,7 @@ facility:
       control_type: ABSOLUTE
       variables:
         cur: 0.023
-      controls: 
+      controls:
         - parameter: a_kicker>MagneticMultipoleP.Kn0
           expression: 0.075*sin(cur)
         ...
@@ -148,10 +145,10 @@ facility:
       control_type: ABSOLUTE
       variables:
         cur: 0.044
-      controls: 
-          - parameter: a_kicker>MagneticMultipoleP.Kn0
-            expression: 0.123*cur
-          ...           
+      controls:
+        - parameter: a_kicker>MagneticMultipoleP.Kn0
+          expression: 0.123*cur
+        ...           
 ```
 Here two controllers control the `Kn0` parameter of the `a_kicker` element.
 In a case where there are multiple `ABSOLUTE` controllers controlling the same parameter,

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -60,7 +60,7 @@ facility:
         description: Model Mitsubishi 800KL
       variables:
         cur1: 0.023
-        cur2: cur1 / c_light
+        cur2: 1e8 / c_light
         ...
       controls:
         - parameter: Qa.*>MagneticMultipoleP.Ks2L  # Parameter control specification.

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -56,6 +56,8 @@ facility:
   - ps27:                             # Controller name
       kind: Controller
       control_type: ABSOLUTE           # Or RELATIVE.
+      MetaP:
+        description: Model Mitsubishi 800KL
       variables:
         cur1: 0.023
         cur2: cur1 / c_light
@@ -76,6 +78,9 @@ used in setting the parameters matched to.
 In the above example, the first `controls` entry will match to the `Ks2L` 
 component of all elements whose name begins with `Qa`, and the associated expression
 is `0.075*sin(cur1) + 0.3*cur2`.
+
+Besides control information, a controller can contain a [`MetaP`](#s:meta.params) parameter group
+which aids in documentation and searching.
 
 Controllers can control the variables of other controllers. The syntax for a controller 
 variable is:

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -178,4 +178,7 @@ A given lattice parameter may be controlled by multiple `ABSOLUTE` controllers o
 controllers but may not (because it does not make sense) be controlled by both `ABSOLUTE` and
 `RELATIVE` controllers.
 
+A given lattice parameter may not be assigned a delayed evaluation expression and be controlled 
+by a controller.
+
 

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -40,3 +40,9 @@ For sets that only have a value, an alternative compact form has the syntax:
     - param2: value2
     ...
 ```
+
+%---------------------------------------------------------------------------------------------------
+(s:controller)=
+## Controllers
+
+A `Controller` is a construct that

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -45,14 +45,125 @@ For sets that only have a value, an alternative compact form has the syntax:
 (s:controller)=
 ## Controllers
 
-A `Controller` is a construct that essentially bundles expressions used for lattice
-element parameter values into one "package".
-Controllers typically represent a physical object like a power supply controlling magnets
-in a machine. 
-Controller syntax:
+A `Controller` is a construct that essentially bundles expressions used used to set lattice
+parameter values into one "package".
+Controllers typically represent a physical object like a power supply controlling magnet elements
+in a machine. Example:
 ```{code} yaml
 facility:
-  - controller:
-      type: controller_type
-      control:                   # Parmeters 
-        - parameter: parameter_
+  - ps27:                             # Name of the Controller
+      - kind: Controller
+      - control_type: ABSOLUTE        # Or RELATIVE.
+      - variables:
+          - cur1: 0.023
+          - cur2: cur1 / c_light
+          ...
+      - control:                      # Parameter control specification.
+          parameter: Qa.*>MagneticMultipoleP.Ks2L
+          expression: 0.075*sin(cur1) + 0.3*cur2
+      - control:                      # Another control specifiction
+          ...           
+      ...
+```
+In this example, a controller called `ps27` has two variables used to control parameters called
+`cur1` and `cur2`. Initial values can be set for variables. The default is value of a variable is zero.
+The parameters controlled are set by one or more `control` groups. These
+`control` groups have a `parameter` component giving the [regular expression](#s:parameter.matching) to 
+match parameters to. In the above example, the first `control` group will match to the `Ks2L` 
+component of all elements whose name begins with `Qa`. The `expression` component gives
+the expression used in setting the parameters matched to. In this example, that expression is
+`0.075*sin(cur1) + 0.3*cur2`.
+
+Controllers can control the variables of other controllers. The syntax for a controller 
+variable is:
+```{code} yaml
+{controller-name}>{variable-name}
+```
+So, for example, with the above example, outside of the `ps27` controller the `cur1` variable
+has the name `ps27>cur1`. While controllers can control the variables of other controllers,
+circular definitions are not allowed.
+
+There are two types of controllers that are differentiated by the setting of the controller's
+`control_type` parameter. The possible settings of `control_type`:
+```{code} yaml
+ABSOLUTE          # Default. Absolute control.
+RELATIVE          # Relative control.
+```
+
+`RELATIVE` type controllers are meant for simulating something like a control system orbit bump knob
+where a change in the knob value results in changes to a set of steerings that are used to
+locally change the orbit in a section of a machine. Example:
+```{code} yaml
+facility:
+  - chrom_a
+      - kind: Controller
+      - control_type: RELATIVE
+      - variables:
+          - command: 0.4
+      - control:
+          parameter: S1>MagneticMultipoleP.Kn2L
+          expression: 5.62 * command + 0.02 * command^2
+      - control:
+          parameter: S2>MagneticMultipoleP.Kn2L
+          expression: -4.72 * command + 0.13 * command^2
+      - control:
+          ...
+      ...
+
+  - S1
+      kind: Sextupole
+      MagneticMultipoleP:
+        kn2L: 0.33
+```
+Here `chrom_a` is a knob for controlling the chromaticity in a ring. `chrom_a` has a
+variable `command` and varies a set of sextupoles. When the PALS file is read in, the
+the sextupole `Kn2L` strengths are set by the values in the elements themselves. In the above
+example, the initial setting of `Kn2L` for element `S1` will be 0.33. After the lattice has
+been read in by a simulation program, variation of the `command` setting of `chrom_a` will
+result in variation of the controlled `Kn2L` parameter values. In the example, if the `command`
+value is changed from `v1` (which is 0.4 at the beginning) to some other value `v2` the change
+in `Kn2L` of `S1` will be:
+```{code} yaml
+change in MagneticMultipoleP.Kn2L = (5.62*v2 + 0.02*v2^2) - (5.62*v1 + 0.02*v1^2) 
+```
+
+`ABSOLUTE` type controllers are meant for simulating something like power supplies controlling 
+magnet strengths where the setting of the power supplies completely determine the magnet strengths.
+Example:
+```{code} yaml
+facility:
+  - ps1: 
+      - kind: Controller
+      - control_type: ABSOLUTE
+      - variables:
+          - cur: 0.023
+      - control: 
+          parameter: a_kicker>MagneticMultipoleP.Kn0
+          expression: 0.075*sin(cur)
+      - control:
+          ...           
+      ...
+
+  - ps2:
+      - kind: Controller
+      - control_type: ABSOLUTE
+      - variables:
+          - cur: 0.044
+      - control: 
+          parameter: a_kicker>MagneticMultipoleP.Kn0
+          expression: 0.123*cur
+      - control:
+          ...           
+      ...
+```
+Here two controllers control the `Kn0` parameter of the `a_kicker` element.
+In a case where there are multiple `ABSOLUTE` controllers controlling the same parameter,
+the value of the parameter is the sum of the values set by the individual controllers.
+In the present example, the value of `Kn0` for `a_kicker` would be:
+ ```{code} yaml
+a_kicker>MagneticMultipoleP.Kn0 = 0.075*sin(ps1>cur) + 0.123*ps2>cur
+```
+
+A given lattice parameter may be controlled by multiple `ABSOLUTE` controllers or multipole `RELATIVE` 
+controllers but may not (because it does not make sense) be controlled by both `ABSOLUTE` and
+`RELATIVE` controllers.

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -46,7 +46,9 @@ For sets that only have a value, an alternative compact form has the syntax:
 ## Controllers
 
 A `Controller` is a construct that essentially bundles expressions used to set lattice
-parameter values into one "package".
+parameter values into one "package". 
+While expressions can be used in place of controllers, 
+controllers add a level of organization and modularity that make them useful constructs. 
 Controllers typically represent a physical object like a power supply controlling magnet elements
 in a machine. Example:
 ```{code} yaml

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -45,33 +45,37 @@ For sets that only have a value, an alternative compact form has the syntax:
 (s:controller)=
 ## Controllers
 
-A `Controller` is a construct that essentially bundles expressions used used to set lattice
+A `Controller` is a construct that essentially bundles expressions used to set lattice
 parameter values into one "package".
 Controllers typically represent a physical object like a power supply controlling magnet elements
 in a machine. Example:
 ```{code} yaml
 facility:
-  - ps27:                             # Name of the Controller
-      - kind: Controller
-      - control_type: ABSOLUTE        # Or RELATIVE.
-      - variables:
-          - cur1: 0.023
-          - cur2: cur1 / c_light
-          ...
-      - control:                      # Parameter control specification.
-          parameter: Qa.*>MagneticMultipoleP.Ks2L
+  - ps27:                             # Controller name
+      kind: Controller
+      control_type: ABSOLUTE           # Or RELATIVE.
+      variables:
+        cur1: 0.023
+        cur2: cur1 / c_light
+        ...
+      controls:                        
+        - parameter: Qa.*>MagneticMultipoleP.Ks2L  # Parameter control specification.
           expression: 0.075*sin(cur1) + 0.3*cur2
-      - control:                      # Another control specifiction
-          ...           
-      ...
+        - parameter: ...                           # Another specification
+          expression: ...           
+       ...
 ```
 In this example, a controller called `ps27` has two variables used to control parameters called
-`cur1` and `cur2`. Initial values can be set for variables. The default is value of a variable is zero.
-The parameters controlled are set by one or more `control` groups. These
-`control` groups have a `parameter` component giving the [regular expression](#s:parameter.matching) to 
-match parameters to. In the above example, the first `control` group will match to the `Ks2L` 
-component of all elements whose name begins with `Qa`. The `expression` component gives
-the expression used in setting the parameters matched to. In this example, that expression is
+`cur1` and `cur2`. Initial values can be set for variables. The default value of a variable is zero.
+The parameters controlled are set by the `controls` component. Each entry has a 
+`parameter` component giving the [regular expression](#s:parameter.matching) to 
+match parameters to and an `expression` component that gives the arithmetic expression
+used in setting the parameters matched to. 
+In the above example, the first `controls` group will match to the `Ks2L` 
+component of all elements whose name begins with `Qa`. 
+
+
+ In this example, that expression is
 `0.075*sin(cur1) + 0.3*cur2`.
 
 Controllers can control the variables of other controllers. The syntax for a controller 
@@ -95,29 +99,26 @@ where a change in the knob value results in changes to a set of steerings that a
 locally change the orbit in a section of a machine. Example:
 ```{code} yaml
 facility:
-  - chrom_a
-      - kind: Controller
-      - control_type: RELATIVE
-      - variables:
-          - command: 0.4
-      - control:
-          parameter: S1>MagneticMultipoleP.Kn2L
+  - chrom_a:
+      kind: Controller
+      control_type: RELATIVE
+      variables:
+        command: 0.4
+      controls:
+        - parameter: S1>MagneticMultipoleP.Kn2L
           expression: 5.62 * command + 0.02 * command^2
-      - control:
-          parameter: S2>MagneticMultipoleP.Kn2L
+        - parameter: S2>MagneticMultipoleP.Kn2L
           expression: -4.72 * command + 0.13 * command^2
-      - control:
-          ...
-      ...
+        ...
 
-  - S1
+  - S1:
       kind: Sextupole
       MagneticMultipoleP:
-        kn2L: 0.33
+        Kn2L: 0.33
 ```
 Here `chrom_a` is a knob for controlling the chromaticity in a ring. `chrom_a` has a
 variable `command` and varies a set of sextupoles. When the PALS file is read in, the
-the sextupole `Kn2L` strengths are set by the values in the elements themselves. In the above
+sextupole `Kn2L` strengths are set by the values in the elements themselves. In the above
 example, the initial setting of `Kn2L` for element `S1` will be 0.33. After the lattice has
 been read in by a simulation program, variation of the `command` setting of `chrom_a` will
 result in variation of the controlled `Kn2L` parameter values. In the example, if the `command`
@@ -133,28 +134,24 @@ Example:
 ```{code} yaml
 facility:
   - ps1: 
-      - kind: Controller
-      - control_type: ABSOLUTE
-      - variables:
-          - cur: 0.023
-      - control: 
-          parameter: a_kicker>MagneticMultipoleP.Kn0
+      kind: Controller
+      control_type: ABSOLUTE
+      variables:
+        cur: 0.023
+      controls: 
+        - parameter: a_kicker>MagneticMultipoleP.Kn0
           expression: 0.075*sin(cur)
-      - control:
-          ...           
-      ...
+        ...
 
   - ps2:
-      - kind: Controller
-      - control_type: ABSOLUTE
-      - variables:
-          - cur: 0.044
-      - control: 
-          parameter: a_kicker>MagneticMultipoleP.Kn0
-          expression: 0.123*cur
-      - control:
+      kind: Controller
+      control_type: ABSOLUTE
+      variables:
+        cur: 0.044
+      controls: 
+          - parameter: a_kicker>MagneticMultipoleP.Kn0
+            expression: 0.123*cur
           ...           
-      ...
 ```
 Here two controllers control the `Kn0` parameter of the `a_kicker` element.
 In a case where there are multiple `ABSOLUTE` controllers controlling the same parameter,
@@ -164,6 +161,6 @@ In the present example, the value of `Kn0` for `a_kicker` would be:
 a_kicker>MagneticMultipoleP.Kn0 = 0.075*sin(ps1>cur) + 0.123*ps2>cur
 ```
 
-A given lattice parameter may be controlled by multiple `ABSOLUTE` controllers or multipole `RELATIVE` 
+A given lattice parameter may be controlled by multiple `ABSOLUTE` controllers or multiple `RELATIVE` 
 controllers but may not (because it does not make sense) be controlled by both `ABSOLUTE` and
 `RELATIVE` controllers.

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -79,6 +79,9 @@ In the above example, the first `controls` entry will match to the `Ks2L`
 component of all elements whose name begins with `Qa`, and the associated expression
 is `0.075*sin(cur1) + 0.3*cur2`.
 
+Note: All controller expressions are considered to be ["delayed evaluation"](#s:expressions)
+as it does not make sense for these expressions to be considered immediate.
+
 Besides control information, a controller can contain a [`MetaP`](#s:meta.params) parameter group
 which aids in documentation and searching.
 

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -58,11 +58,11 @@ facility:
         cur1: 0.023
         cur2: cur1 / c_light
         ...
-      controls: 
+      controls:
         - parameter: Qa.*>MagneticMultipoleP.Ks2L  # Parameter control specification.
           expression: 0.075*sin(cur1) + 0.3*cur2
         - parameter: ...                           # Another specification
-          expression: ...           
+          expression: ...   
         ...
 ```
 In this example, a controller called `ps27` has two variables used to control parameters called
@@ -122,7 +122,7 @@ result in variation of the controlled `Kn2L` parameter values. In the example, i
 value is changed from `v1` (which is 0.4 at the beginning) to some other value `v2` the change
 in `Kn2L` of `S1` will be:
 ```{code} yaml
-change in MagneticMultipoleP.Kn2L = (5.62*v2 + 0.02*v2^2) - (5.62*v1 + 0.02*v1^2) 
+change in MagneticMultipoleP.Kn2L = (5.62*v2 + 0.02*v2^2) - (5.62*v1 + 0.02*v1^2)
 ```
 
 `ABSOLUTE` type controllers are meant for simulating something like power supplies controlling 
@@ -148,13 +148,13 @@ facility:
       controls:
         - parameter: a_kicker>MagneticMultipoleP.Kn0
           expression: 0.123*cur
-        ...           
+        ...
 ```
 Here two controllers control the `Kn0` parameter of the `a_kicker` element.
 In a case where there are multiple `ABSOLUTE` controllers controlling the same parameter,
 the value of the parameter is the sum of the values set by the individual controllers.
 In the present example, the value of `Kn0` for `a_kicker` would be:
- ```{code} yaml
+```{code} yaml
 a_kicker>MagneticMultipoleP.Kn0 = 0.075*sin(ps1>cur) + 0.123*ps2>cur
 ```
 

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -99,6 +99,7 @@ So, for example, with the above example, outside of the `ps27` controller the `c
 has the name `ps27>cur1`. While controllers can control the variables of other controllers,
 circular definitions are not allowed. The set of all controllers thus forms a hierarchy and
 controller evaluation works by starting at the top of the hierarchy and working downwards.
+The order in which controllers are defined in the PALS file is irrelevant to controller evaluation.
 
 There are two types of controllers that are differentiated by the setting of the controller's
 `control_type` parameter. The possible settings of `control_type`:

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -79,7 +79,12 @@ In the above example, the first `controls` entry will match to the `Ks2L`
 component of all elements whose name begins with `Qa`, and the associated expression
 is `0.075*sin(cur1) + 0.3*cur2`.
 
-Note: All controller expressions are considered to be ["delayed evaluation"](#s:expressions)
+Initial values for controller variables may be equations. These equations and the equations
+used for `expression`s are not allowed
+to contain lattice parameters nor variables as this could greatly complicate the problem of 
+evaluation order.
+
+Note: All controller `expression`s are considered to be ["delayed evaluation"](#s:expressions)
 as it does not make sense for these expressions to be considered immediate.
 
 Besides control information, a controller can contain a [`MetaP`](#s:meta.params) parameter group
@@ -92,7 +97,8 @@ variable is:
 ```
 So, for example, with the above example, outside of the `ps27` controller the `cur1` variable
 has the name `ps27>cur1`. While controllers can control the variables of other controllers,
-circular definitions are not allowed.
+circular definitions are not allowed. The set of all controllers thus forms a hierarchy and
+controller evaluation works by starting at the top of the hierarchy and working downwards.
 
 There are two types of controllers that are differentiated by the setting of the controller's
 `control_type` parameter. The possible settings of `control_type`:
@@ -171,3 +177,5 @@ a_kicker>MagneticMultipoleP.Kn0 = 0.075*sin(ps1>cur) + 0.123*ps2>cur
 A given lattice parameter may be controlled by multiple `ABSOLUTE` controllers or multiple `RELATIVE` 
 controllers but may not (because it does not make sense) be controlled by both `ABSOLUTE` and
 `RELATIVE` controllers.
+
+

--- a/source/miscellaneous.md
+++ b/source/miscellaneous.md
@@ -45,4 +45,14 @@ For sets that only have a value, an alternative compact form has the syntax:
 (s:controller)=
 ## Controllers
 
-A `Controller` is a construct that
+A `Controller` is a construct that essentially bundles expressions used for lattice
+element parameter values into one "package".
+Controllers typically represent a physical object like a power supply controlling magnets
+in a machine. 
+Controller syntax:
+```{code} yaml
+facility:
+  - controller:
+      type: controller_type
+      control:                   # Parmeters 
+        - parameter: parameter_


### PR DESCRIPTION
With Bmad, controllers are widely used in simulations of a wide range of machines at a number of laboratories This is due to the fact that what controllers simulate are basic building blocks for virtually all accelerators. While deferred expressions can be used in place of controllers, controllers add a level of organization and modularity that make them useful constructs.  The ability to add documentation to a controller and the ease of being able to search and sort by controller name are features that deferred expressions lack.

Close #235