### PR TITLE
Add front matter, GitHub repository link button

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -33,5 +33,7 @@ html_theme_options = {
     "show_toc_level": 3,
     "show_navbar_depth": 3,
     "collapse_navbar": False,
+    "repository_url": "https://github.com/pals-project/pals",
+    "use_repository_button": True,
 }
 ## html_static_path = ['_static']

--- a/source/index.md
+++ b/source/index.md
@@ -1,6 +1,71 @@
 # PALS: Particle Accelerator Language Standard
 
-Welcome to PALS, a standard to promote lattice information exchange for particle accelerators.
+The **Particle Accelerator Language Standard (PALS)** defines a common, language-neutral
+way to describe the lattices and machine information of particle accelerators and storage
+rings — so that this information can be shared freely between simulation programs,
+published, archived, and analyzed with a single, unified description.
+
+A PALS-based lattice can hold the information for an entire machine complex, from beam
+creation through to the dump lines, enabling start-to-end simulations built on a single
+lattice. PALS itself does not perform simulations or tracking; it is the standardized
+*description* that simulation programs read from and write to.
+
+```{admonition} Why PALS?
+:class: tip
+
+- **Portability** between applications and differing algorithms
+- **Open access** description of scientific data for publishing and archiving
+- **A unified basis** for post-processing, visualization, and analysis
+```
+
+## Explore the standard
+
+::::{grid} 1 1 2 2
+:gutter: 3
+
+:::{grid-item-card} 🚀 Overview
+:link: overview
+:link-type: doc
+
+What PALS is, what it is not, and how simulation programs interact with a PALS file.
+:::
+
+:::{grid-item-card} 📐 Fundamentals
+:link: fundamentals
+:link-type: doc
+
+Core concepts, notation, and coordinate conventions used throughout the schema.
+:::
+
+:::{grid-item-card} 🧩 Lattice Elements
+:link: lattice-elements
+:link-type: doc
+
+The standardized element kinds, their parameters, and how they are grouped.
+:::
+
+:::{grid-item-card} 🔗 Beamlines & Construction
+:link: beamlines
+:link-type: doc
+
+Organizing elements into lines and branches to describe an entire machine complex.
+:::
+
+:::{grid-item-card} 💻 Implementations
+:link: code-packages
+:link-type: doc
+
+Code packages and simulation programs that read and write PALS files.
+:::
+
+:::{grid-item-card} 🤝 Contributing
+:link: contributing
+:link-type: doc
+
+Governance, how to contribute, and guidelines for writing documentation.
+:::
+
+::::
 
 ```{toctree}
 :maxdepth: 2


### PR DESCRIPTION
## Summary

The web docs at https://pals-project.readthedocs.io/en/latest/ did not have a link back to the GitHub repository. This adds a GitHub repository button to the `sphinx_book_theme` header.

Changes to `source/conf.py`:
- `repository_url` — points to `https://github.com/pals-project/pals`
- `use_repository_button: True` — renders a GitHub button in the header

Once the docs rebuild on Read the Docs, a GitHub button will appear in the top navbar linking back to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)