### PR TITLE
Name matching

### DIFF
--- a/source/fundamentals.md
+++ b/source/fundamentals.md
@@ -125,47 +125,61 @@ to the following:
 (s:name.matching)=
 ## Name Matching
 
-PALS defines a standard syntax for name matching.
-For element parameters, the general syntax is
+Name matching is the process of finding the set of named constructs — lattice
+elements, element parameter groups, element parameters, constants, variables,
+etc. — that a given string is matched to. PALS defines a standard syntax for this.
+
+At its simplest, a string is matched against the `name` of a construct. For
+example, `qa.*` matches every element (or constant, variable, ...) whose name
+begins with `qa`. Names may be [PCRE2](https://www.pcre.org/) regular
+expressions. Regex matching is a whole-name (fully anchored) match — the pattern
+must match the entire name — so `qa.*` matches any name beginning with `qa`,
+while `qa` on its own matches only the exact name `qa`.
+
+Element parameters are matched by appending the parameter path to an element name
+match, using a single `>` as the separator:
 ```{code} text
-{beamline}>>{element-name}>{parameter-group}.{sub-group1}. ... .{sub-groupN}.{parameter} or
-{branch-name}>>{element-name}>{parameter-group}.{sub-group1}. ... .{sub-groupN}.{parameter}
-{kind}>>{element-name}>{parameter-group}.{sub-group1}. ... .{sub-groupN}.{parameter}
+{element-name}>{parameter-group}.{sub-group1}. ... .{sub-groupN}.{parameter}
 ```
 where
 ```{code} yaml
-{beamline}                      # Optional BeamLine name.
-{branch-name}                   # Optional Branch name.
-{kind}                          # Optional element kind name.
-{element-name}                  # Optional element name.
+{element-name}                  # Element name match, see below.
 {parameter-group}               # Parameter group name.
 {sub-group1}. ... .{sub-groupN} # Subgroups if they exist.
 {parameter}                     # Parameter name.
 ```
-Only `{beamline}`, `{branch-name},` and `{element-name}` use PCRE2 syntax. 
+The `{element-name}` component is any element name match from
+[Element Name Matching](#s:element.matching) — including its kind (`::`),
+BeamLine/Branch (`>>`), and Lattice (`>>>`) qualifiers. The parameter path
+following the `>` is, unlike element names, matched exactly rather than with
+PCRE2; the dots within it are therefore unambiguous, and the single `>`
+separator is distinct from the `>>` and `>>>` qualifiers that may appear inside
+`{element-name}`.
 
 Example:
 ```{code} yaml
 qa.*>MagneticMultipoleP.Ks2L
-Quadrupole>>qa.*>MagneticMultipoleP.Ks2L
+Quadrupole::qa.*>MagneticMultipoleP.Ks2L
 ```
-The first line will match the `Ks2L` component of all elements whose name begins with `qa`. Notice that
-since only `{beamline}` and `{element-name}` use PCRE2 syntax, the dot separating the parameter group
-and the parameter is unambiguous. The second line is like the first except only `Quadrupole` kind
-elements are matched to.
+The first line matches the `Ks2L` component of `MagneticMultipoleP` for all
+elements whose name begins with `qa`. The second is the same but restricted to
+elements of kind `Quadrupole`.
 
-Element parameter groups can similarly be matched to by using the above syntax without any
-`{parameter}` component. Similarly, Elements can be matched to if the `{parameter-group}`
-and everything following is not present. Example:
+A trailing part of the path may be dropped to match the enclosing construct
+instead of a parameter: omit `{parameter}` to match a parameter group, or omit
+the `>{parameter-group}...` entirely to match the element itself. Example:
 ```{code} yaml
-qa.*>MagneticMultipoleP    # Match to MagnetMultipoleP parameter group.
-qa.*                       # Match to element.
-Controller>>cd.t           # Match to all controllers whose four character name starts with `cd` and ends with `t`.
+qa.*>MagneticMultipoleP    # Match the MagneticMultipoleP parameter group.
+qa.*                       # Match the element.
+Controller::cd.t           # Match all Controllers whose four-character name starts with `cd` and ends with `t`.
 ```
+Constructs that are not element parameters — for example
+[constants and variables](#s:constants) — are matched directly by name, with no
+`>`-qualified parameter path.
 
 %---------------------------------------------------------------------------------------------------
 (s:specialvalues)=
-### Special Values
+## Special Values
 
 Special values used in this document are:
 

--- a/source/fundamentals.md
+++ b/source/fundamentals.md
@@ -123,23 +123,12 @@ to the following:
 
 %---------------------------------------------------------------------------------------------------
 (s:name.matching)=
+(s:parameter.matching)=
 ## Name Matching
 
 Name matching is the process of finding the set of named constructs — lattice
 elements, element parameter groups, element parameters, constants, variables,
 etc. — that a given string is matched to. PALS defines a standard syntax for this.
-
-Name matches may be restricted to a given element kind using the notation
-```{code} yaml
-{kind}::{name}
-```
-where `{kind}` is the element kind and `{name}` is the element name.
-Example:
-```{code} yaml
-Marker::bpm.
-```
-This will match to all `Marker` elements whose name is four characters starting with `bpm`
-(since a dot matches to any single character, see below).
 
 At its simplest, a string is matched against the `name` of a construct. For
 example, `qa.*` matches every element (or constant, variable, ...) whose name
@@ -148,15 +137,37 @@ expressions. Regex matching is a whole-name (fully anchored) match — the patte
 must match the entire name — so `qa.*` matches any name beginning with `qa`,
 while `qa` on its own matches only the exact name `qa`.
 
+Name matches may be restricted to a given construct kind using the notation
+```{code} yaml
+{kind}::{name}
+```
+where `{kind}` is the construct kind — for example a lattice element kind such as
+`Marker`, or a non-element kind such as `Controller` — and `{name}` is the name
+match. The `{kind}` selector resolves within the namespace of the given kind, so
+the same `{name}` may match different constructs depending on the kind supplied.
+Example:
+```{code} yaml
+Marker::bpm.
+```
+This will match to all `Marker` elements whose name is four characters starting with `bpm`
+(since a dot matches to any single character, see below).
+
 Element parameters are matched by appending the parameter path to an element name
-match, using a single `>` as the separator:
+match, using a single `>` as the separator. A parameter that belongs to a
+[parameter group](#s:param.groups) is matched using the group path:
 ```{code} text
 {element-name}>{parameter-group}.{sub-group1}. ... .{sub-groupN}.{parameter}
+```
+while a parameter that is not in any group — for example `length`, `is_on`, or
+the element kind (see [Non-Group Parameters](#s:non.params)) — is matched
+directly:
+```{code} text
+{element-name}>{parameter}
 ```
 where
 ```{code} yaml
 {element-name}                  # Element name match, see below.
-{parameter-group}               # Parameter group name if it exists (EG length in not in a group).
+{parameter-group}               # Parameter group name (for grouped parameters).
 {sub-group1}. ... .{sub-groupN} # Subgroups if they exist.
 {parameter}                     # Parameter name.
 ```
@@ -172,10 +183,12 @@ Example:
 ```{code} yaml
 qa.*>MagneticMultipoleP.Ks2L
 Quadrupole::qa.*>MagneticMultipoleP.Ks2L
+Q1>length
 ```
 The first line matches the `Ks2L` component of `MagneticMultipoleP` for all
 elements whose name begins with `qa`. The second is the same but restricted to
-elements of kind `Quadrupole`.
+elements of kind `Quadrupole`. The third matches the ungrouped `length`
+parameter of the element `Q1`.
 
 A trailing part of the path may be dropped to match the enclosing construct
 instead of a parameter: omit `{parameter}` to match a parameter group, or omit
@@ -185,6 +198,13 @@ qa.*>MagneticMultipoleP    # Match the MagneticMultipoleP parameter group.
 qa.*                       # Match the element.
 Controller::cd.t           # Match all Controllers whose four-character name starts with `cd` and ends with `t`.
 ```
+
+Constructs that are not element parameters are matched by name in the same way.
+Top-level [constants and variables](#s:constants) are matched directly, with no
+`>`-qualified path. A variable that is owned by a controller, however, is matched
+through its controller using the same single `>` separator —
+`{controller-name}>{variable-name}` — just as an element parameter is reached
+through its element.
 
 %---------------------------------------------------------------------------------------------------
 (s:specialvalues)=

--- a/source/fundamentals.md
+++ b/source/fundamentals.md
@@ -129,6 +129,18 @@ Name matching is the process of finding the set of named constructs — lattice
 elements, element parameter groups, element parameters, constants, variables,
 etc. — that a given string is matched to. PALS defines a standard syntax for this.
 
+Name matches may be restricted to a given element kind using the notation
+```{code} yaml
+{kind}::{name}
+```
+where `{kind}` is the element kind and `{name}` is the element name.
+Example:
+```{code} yaml
+Marker::bpm.
+```
+This will match to all `Marker` elements whose name is four characters starting with `bpm`
+(since a dot matches to any single character, see below).
+
 At its simplest, a string is matched against the `name` of a construct. For
 example, `qa.*` matches every element (or constant, variable, ...) whose name
 begins with `qa`. Names may be [PCRE2](https://www.pcre.org/) regular
@@ -144,7 +156,7 @@ match, using a single `>` as the separator:
 where
 ```{code} yaml
 {element-name}                  # Element name match, see below.
-{parameter-group}               # Parameter group name.
+{parameter-group}               # Parameter group name if it exists (EG length in not in a group).
 {sub-group1}. ... .{sub-groupN} # Subgroups if they exist.
 {parameter}                     # Parameter name.
 ```
@@ -173,9 +185,6 @@ qa.*>MagneticMultipoleP    # Match the MagneticMultipoleP parameter group.
 qa.*                       # Match the element.
 Controller::cd.t           # Match all Controllers whose four-character name starts with `cd` and ends with `t`.
 ```
-Constructs that are not element parameters — for example
-[constants and variables](#s:constants) — are matched directly by name, with no
-`>`-qualified parameter path.
 
 %---------------------------------------------------------------------------------------------------
 (s:specialvalues)=

--- a/source/fundamentals.md
+++ b/source/fundamentals.md
@@ -122,6 +122,48 @@ to the following:
 - A name can only contain alpha-numeric characters and underscores (A-Z, a-z, 0-9, and _ )
 
 %---------------------------------------------------------------------------------------------------
+(s:name.matching)=
+## Name Matching
+
+PALS defines a standard syntax for name matching.
+For element parameters, the general syntax is
+```{code} text
+{beamline}>>{element-name}>{parameter-group}.{sub-group1}. ... .{sub-groupN}.{parameter} or
+{branch-name}>>{element-name}>{parameter-group}.{sub-group1}. ... .{sub-groupN}.{parameter}
+{kind}>>{element-name}>{parameter-group}.{sub-group1}. ... .{sub-groupN}.{parameter}
+```
+where
+```{code} yaml
+{beamline}                      # Optional BeamLine name.
+{branch-name}                   # Optional Branch name.
+{kind}                          # Optional element kind name.
+{element-name}                  # Optional element name.
+{parameter-group}               # Parameter group name.
+{sub-group1}. ... .{sub-groupN} # Subgroups if they exist.
+{parameter}                     # Parameter name.
+```
+Only `{beamline}`, `{branch-name},` and `{element-name}` use PCRE2 syntax. 
+
+Example:
+```{code} yaml
+qa.*>MagneticMultipoleP.Ks2L
+Quadrupole>>qa.*>MagneticMultipoleP.Ks2L
+```
+The first line will match the `Ks2L` component of all elements whose name begins with `qa`. Notice that
+since only `{beamline}` and `{element-name}` use PCRE2 syntax, the dot separating the parameter group
+and the parameter is unambiguous. The second line is like the first except only `Quadrupole` kind
+elements are matched to.
+
+Element parameter groups can similarly be matched to by using the above syntax without any
+`{parameter}` component. Similarly, Elements can be matched to if the `{parameter-group}`
+and everything following is not present. Example:
+```{code} yaml
+qa.*>MagneticMultipoleP    # Match to MagnetMultipoleP parameter group.
+qa.*                       # Match to element.
+Controller>>cd.t           # Match to all controllers whose four character name starts with `cd` and ends with `t`.
+```
+
+%---------------------------------------------------------------------------------------------------
 (s:specialvalues)=
 ### Special Values
 

--- a/source/fundamentals.md
+++ b/source/fundamentals.md
@@ -143,9 +143,7 @@ Name matches may be restricted to a given construct kind using the notation
 ```
 where `{kind}` is the construct kind — for example a lattice element kind such as
 `Marker`, or a non-element kind such as `Controller` — and `{name}` is the name
-match. The `{kind}` selector resolves within the namespace of the given kind, so
-the same `{name}` may match different constructs depending on the kind supplied.
-Example:
+match. Example:
 ```{code} yaml
 Marker::bpm.
 ```

--- a/source/fundamentals.md
+++ b/source/fundamentals.md
@@ -150,7 +150,7 @@ Example:
 Marker::bpm.
 ```
 This will match to all `Marker` elements whose name is four characters starting with `bpm`
-(since a dot matches to any single character, see below).
+(since a dot matches to any single character).
 
 Element parameters are matched by appending the parameter path to an element name
 match, using a single `>` as the separator. A parameter that belongs to a

--- a/source/lattice-element-parameters.md
+++ b/source/lattice-element-parameters.md
@@ -58,32 +58,6 @@ cleo:             # [string] user-defined name
 ```
 
 %---------------------------------------------------------------------------------------------------
-(s:parameter.matching)=
-## Element Parameter Name Matching
-
-For element parameters, the general syntax is
-```{code} text
-{beamline}>>{element}>{parameter-group}.{sub-group1}. ... .{sub-groupN}.{parameter}
-```
-where
-```{code} yaml
-{beamline}                      # Optional BeamLine or Branch name.
-{element}                       # Optional lattice element name.
-{parameter-group}               # Parameter group name.
-{sub-group1}. ... .{sub-groupN} # Subgroups if they exist.
-{parameter}                     # Parameter name.
-```
-Only `{beamline}` and `{element}` use PCRE2 syntax. 
-
-Example:
-```{code} yaml
-Qa.*>MagneticMultipoleP.Ks2L
-```
-This will match the `Ks2L` component of all elements whose name begins with `Qa`. Notice that
-since only `{beamline}` and `{element}` use PCRE2 syntax, the dot separating the parameter group
-and the parameter is unambiguous.
-
-%---------------------------------------------------------------------------------------------------
 (s:inherit.params)=
 ## Naming and Inheriting Parameters
 

--- a/source/lattice-elements.md
+++ b/source/lattice-elements.md
@@ -87,18 +87,6 @@ The simplest form of name matching is if the string matches
 the `name` field of an element or elements. 
 For example, the string `"Q1"` will match to all elements named `Q1`.
 
-Element matches may be restricted to a given element kind using the notation
-```{code} yaml
-{kind}::{name}
-```
-where `{kind}` is the element kind and `{name}` is the element name.
-Example:
-```{code} yaml
-Marker::bpm.
-```
-This will match to all `Marker` elements whose name is four characters starting with `bpm`
-(since a dot matches to any single character, see below).
-
 The `N`{sup}`th` element with a given name can be matched to by appending the character `"#"` 
 followed by an integer `N`. For example, `"Quadrupole::Q1#3"` will match to the third element
 that matches `"Quadrupole::Q1"`. The `N`{sup}`th` instance selection is always applied last.

--- a/source/lattice-elements.md
+++ b/source/lattice-elements.md
@@ -176,6 +176,7 @@ Order of precedence:
 ```{code}
 >>>     # Highest
 >>
+>
 ::      
 #
 :


### PR DESCRIPTION
Up to now the standard has only discussed lattice element and element parameter name matching. This PR generalizes the discussion to name matching of, say, controllers using the same syntax as for lattice elements.