### PR TITLE
Change `Boolean` to `logical`

### DIFF
--- a/source/beamlines.md
+++ b/source/beamlines.md
@@ -25,7 +25,7 @@ periodic    # [logical] Are orbit and Twiss parameters periodic? Default is Fals
 
 The `name` component is a string that can be used to reference the `BeamLine`.
 
-The optional `multipass` component is a boolean describing whether the `BeamLine` is part of 
+The optional `multipass` component is a logical describing whether the `BeamLine` is part of 
 a [multipass construct](#c:multipass). The default is False.
 
 The optional `length` component gives the length of the `BeamLine`. 
@@ -36,7 +36,7 @@ The optional `zero_point` component is used to position sublines.
 The value of `zero_point` is the name of a line element that marks the reference point. 
 To make things unambiguous, the reference line element must have zero length.
 
-Setting optional `periodic` Boolean to `true` indicates that the `BeamLine` is something like a 
+Setting optional `periodic` logical to `true` indicates that the `BeamLine` is something like a 
 storage ring where the particle beam recirculates through the `BeamLine` multiple times.
 Setting `periodic` to `False` is used to indicate that the `BeamLine` is something like a 
 Linac or any other line that is "single pass". 

--- a/source/fundamentals.md
+++ b/source/fundamentals.md
@@ -127,7 +127,7 @@ to the following:
 
 Special values used in this document are:
 
-1. Boolean parameters can be one of three values:
+1. Logical parameters can be one of three values:
 - `true`
 - `false`
 - `null`: Useful as a default value when neither `true` nor `false` is appropriate.

--- a/source/lattice-construction.md
+++ b/source/lattice-construction.md
@@ -29,7 +29,7 @@ are those branches created due to `Fork` elements.
 A branch has the optional components
 ```{code} yaml
 inherit   # [String] Optional. Name of the root BeamLine for the branch. Default is the name of the Branch.
-periodic  # [Boolean] Optional. Are orbit and Twiss parameters periodic? 
+periodic  # [logical] Optional. Are orbit and Twiss parameters periodic? 
           #   Default is the setting of the root BeamLine.
 ```
 The setting of `periodic` for a `Branch` overrides the setting of `periodic`

--- a/source/lattice-element-parameters.md
+++ b/source/lattice-element-parameters.md
@@ -36,8 +36,8 @@ There are element parameters that are common and do not naturally fit into
 any of the parameter groups. These parameters are not grouped. 
 These element parameters are:
 ```{code} yaml
-  field_master: null    # [Boolean] See Below.
-  is_on: true           # [Boolean] Turns on or off the fields in an element. When off, the element looks like a drift.
+  field_master: null    # [logical] See Below.
+  is_on: true           # [logical] Turns on or off the fields in an element. When off, the element looks like a drift.
   kind: ""              # [enum] Kind of element (Quadrupole, etc.).
   length: 0             # [m] Length of element. For bends this is the arc length.
   name: ""              # [string] The name of element.

--- a/source/parameters/aperture.md
+++ b/source/parameters/aperture.md
@@ -18,8 +18,8 @@ ApertureP:
   vertices: []                     # [array] Array of vertex points. See below.
   material: ""                     # [string] Material of the Aperture
   thickness: 0                     # [m] Real number
-  aperture_shifts_with_body: false # [Boolean] See below.
-  aperture_active: true            # [Boolean] false implies aperture is not operating.
+  aperture_shifts_with_body: false # [logical] See below.
+  aperture_active: true            # [logical] false implies aperture is not operating.
 ```
 The horizontal aperture may be specified by setting `x_min` and `x_max` or by setting
 `x_center` and `x_width` but only one pair may be set. A Similar situation applies to
@@ -137,7 +137,7 @@ subcomponents
 ```{code} yaml
   verticies:
     center: 0                 # [m] Vector of (x, y) center point.
-    absolute_vertices: false  # [Boolean] Default is False.
+    absolute_vertices: false  # [logical] Default is False.
     list: [{}]                # [List of dictionaries] Ordered list of vertex points.
 ```
 The `list` vector can have the components:
@@ -163,7 +163,7 @@ ApertureP:
 ```
 This corresponds roughly to what is shown in {numref}`f:aperture`.
 
-If the boolean `absolute_vertices` is set `False`, which is the default,
+If the logical `absolute_vertices` is set `False`, which is the default,
 the vertex point positions are with respect to the `center` point. 
 That is, the vertex point positions in absolute terms are the positions given with each vertex plus
 the position of the `center`. If `absolute_vertices` is `true`, the vertex point positions 

--- a/source/parameters/floor.md
+++ b/source/parameters/floor.md
@@ -16,7 +16,7 @@ FloorP:
   theta: null                   # [radians] Orientation angle.
   phi: null                     # [radians] Orientation angle.
   psi: null                     # [radians] Orientation angle.
-  user_set: false               # [logic] Is placement set by the user or computed?
+  user_set: false               # [logical] Is placement set by the user or computed?
 ```
 
 When this group is contained in an element, the placement can either be set by the creator

--- a/source/parameters/patch.md
+++ b/source/parameters/patch.md
@@ -29,7 +29,7 @@ PatchP:
                     #    true -> User sets offsets and rot. 
                     #    False -> Offsets and rot from branch layout.
   ref_coords        # [enum] Coordinate system defining the length
-  user_sets_length  # [logic] Default is False. Is the element length User set? 
+  user_sets_length  # [logical] Default is False. Is the element length User set? 
 ```
 
 The transformation from `Patch` entrance coordinates to exit coordinates is given by [](#wws)


### PR DESCRIPTION
Closes #117.

`Boolean` implies there are only two values, but PALS uses [tri-state logic](https://pals-project.readthedocs.io/en/latest/introduction.html#syntax-used-in-this-document) with the added `null`. This renames the type to `logical` throughout the documentation.

### Notes on the details

**Casing.** Lowercase `logical` was already the house style before this change — it appeared 7 times in `beamlines.md`, `patch.md`, `floor.md` and `fork.md`, alongside `[string]`, `[enum]` and `[list]`. So the six `[Boolean]` annotations become `[logical]` to match. The one exception is `fundamentals.md`, where the word opens a numbered sentence ("Logical parameters can be one of three values"), so it is capitalized as a sentence opener rather than as a type name.

**One adjacent cleanup.** The two stragglers spelled `[logic]` (`floor.md`, `patch.md`) are folded into `[logical]` as well, since they name the same type and leaving them would undercut the point of the rename. Happy to drop this if you'd rather keep the diff strictly to `Boolean`.

**Left alone.** `beamlines.md` uses `[switch]` for `direction` (+1 or -1), which is a distinct type rather than a tri-state logical. Separately, @ax3l's P.S. on the issue about updating the `field_master` example from `NotSet` to `null` is already done on `main` — it reads `field_master: null` today.

**Still open from the issue discussion.** @ax3l asked to see examples that cannot sensibly be expressed as true/false, and whether `null` should be allowed on numerical or string values too. This PR does the rename only and does not attempt to answer that.

### Verification

Changes are confined to prose and YAML comments, with no structural markup touched. I was not able to render the docs to confirm — `make html` fails locally with `Could not import extension sphinx_design`, a pre-existing environment gap unrelated to these edits — so this has been checked by grep rather than by a build. Worth letting CI confirm the render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)