### PR TITLE
Attach TwissP and ParticleP to element kinds

### DIFF
--- a/source/lattice-element-kinds.md
+++ b/source/lattice-element-kinds.md
@@ -113,8 +113,10 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 Example:
 ```{code} yaml
@@ -136,8 +138,10 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 Example:
 ```{code} yaml
@@ -166,8 +170,10 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): Twiss, coupling, and dispersion parameters.
 
 The length of this element is considered to be zero so if `length` is specified, it must be zero.
 
@@ -188,8 +194,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 %---------------------------------------------------------------------------------------------------
 (s:converter)=
@@ -209,8 +217,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -227,8 +237,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 Example:
 ```{code} yaml
@@ -251,8 +263,10 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 Example:
 ```{code} yaml
@@ -278,8 +292,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -326,7 +342,9 @@ Also see [`patch`](#s:patch) and [`fiducial`](#s:fiducial) elements.
 Element parameter groups associated with this element kind are:
 - [**FloorShiftP**](#s:floor.shift.params): Floor shift parameters.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -346,8 +364,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**FoilP**](#s:foil.params): Foil parameters.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -368,8 +388,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**ForkP**](#s:fork.params): Required. Fork element parameters.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -402,8 +424,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -423,8 +447,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -440,7 +466,9 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 The `length` of this element must be zero.
 
@@ -464,8 +492,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -482,8 +512,10 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 The length of this element is considered to be zero so if `length` is specified, it must be zero.
 
@@ -502,8 +534,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -521,8 +555,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 Example:
 ```{code} yaml
@@ -568,9 +604,11 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**PatchP**](#s:patch.params): Exit coordinates with respect to entrance coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 Important: By convention, the energy shift is applied after a particle reaches the exit face.
 This matters due to the dependence of the reference velocity on the the reference energy.
@@ -591,8 +629,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 Example:
 ```{code} yaml
@@ -615,9 +655,11 @@ the downstream elements of the `ReferenceChange` element.
 Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceChangeP**](#s:ref.change.params): Reference parameters adjustments.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 %---------------------------------------------------------------------------------------------------
@@ -635,10 +677,12 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**RFP**](#s:rf.params): RF parameters.
 - [**SolenoidP**](#s:solenoid.params): Solenoid field.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 Note: Multipole parameters represent DC fields. A common example is a DC solenoid field which
 helps focusing.
@@ -659,8 +703,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 Example:
 ```{code} yaml
@@ -686,9 +732,11 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**SolenoidP**](#s:solenoid.params): Solenoid field.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 Example:
 ```{code} yaml
@@ -714,9 +762,11 @@ Element parameter groups associated with this element kind are:
 - [**BodyShiftP**](#s:bodyshift.params): Orientation of element with respect to its nominal position.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TaylorP**](#s:taylor.params): Orbital and spin Taylor map.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 The length of this element is considered to be zero so if `length` is specified, it must be zero.
 
@@ -733,8 +783,10 @@ Element parameter groups associated with this element kind are:
 - **elements**: A list of contained element kinds.
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 For each element contained in the `UnionEle`, the nominal position of the contained element is
 such that the center of the contained element is at the center of the `UnionEle` with the
@@ -783,8 +835,10 @@ Element parameter groups associated with this element kind are:
 - [**FloorP**](#s:floor.params): Floor position and orientation.
 - [**MagneticMultipoleP**](#s:mag.mult.params): Magnetic multipoles.
 - [**MetaP**](#s:meta.params): Meta parameters.
+- [**ParticleP**](#s:particle.params): **Output Parameters.** Particle coordinates.
 - [**ReferenceP**](#s:ref.params): **Output Parameters.** Reference parameters.
 - [**TrackingP**](#s:tracking.params): Tracking parameters.
+- [**TwissP**](#s:twiss.params): **Output Parameters.** Twiss, coupling, and dispersion parameters.
 
 
 

--- a/source/lattice-element-parameters.md
+++ b/source/lattice-element-parameters.md
@@ -142,6 +142,7 @@ For an element to inherit all parameter groups from another element, just inheri
 ```
 
 %---------------------------------------------------------------------------------------------------
+(s:io.params)=
 ## User Settable (Input) and Dependent (Output) parameters.
 
 Some parameters are set in the PALS file. These parameters are called "User settable" or "input". 

--- a/source/parameters/particle.md
+++ b/source/parameters/particle.md
@@ -4,6 +4,16 @@
 
 The `ParticleP` parameter group contains parameters for describing single particle coordinates
 or a beam particle distribution that is Gaussian distributed.
+For a [BeginningEle](#s:beginningele) element, `ParticleP` is an input parameter group that sets the
+particle coordinates at the start of a branch.
+For all other element kinds that have a [ReferenceP](#s:ref.params) group, `ParticleP` is an
+[output parameter](#s:io.params) group.
+
+Note that PALS itself does not define how any `ParticleP` component is calculated: that is outside
+the scope of PALS.
+A program is free to track particles and write the resulting coordinates out for each element of an
+expanded lattice so that other programs may read them back in.
+
 The components of this group are:
 ```{code} yaml
 ParticleP:                    # <> denotes average over distribution

--- a/source/parameters/twiss.md
+++ b/source/parameters/twiss.md
@@ -4,6 +4,16 @@
 
 Typically this parameter group is used to specify the initial Twiss, coupling and dispersion
 parameters at the beginning of a lattice branch.
+For a [BeginningEle](#s:beginningele) element, `TwissP` is an input parameter group that sets these
+initial values.
+For all other element kinds that have a [ReferenceP](#s:ref.params) group, `TwissP` is an
+[output parameter](#s:io.params) group.
+
+Note that PALS itself does not define how any `TwissP` component is calculated: that is outside the
+scope of PALS.
+A program is free to compute the Twiss parameters and write them out for each element of an
+expanded lattice so that other programs may read them back in.
+
 The components if `TwissP` are:
 ```{code} yaml
 alpha_a       # [-] "a" mode alpha


### PR DESCRIPTION
Closes #248.

`TwissP` and `ParticleP` were not attached to any element kind, so the spec never said where they may appear.

## What this implements

Following the resolution in #248:

- **`BeginningEle`** — `TwissP` and `ParticleP` are **input** parameter groups, setting the initial Twiss/coupling/dispersion and the particle coordinates at the start of a branch.
- **All other applicable element kinds** — both are **output** parameter groups, using the existing `**Output Parameters.**` convention already used for `ReferenceP`.

PALS still does not define how any component of either group is calculated — that is outside its scope. The docs now say so explicitly, and describe the intended workflow: a program reads a PALS file, computes the Twiss, and writes an expanded lattice with the Twiss embedded per element, which any other program can then read back.

## Which element kinds

Both groups are added to the **27 kinds that have a `ReferenceP` group**. The reference orbit is what Twiss and particle coordinates are defined against, which makes it the natural boundary.

The four kinds left out are exactly those without a `ReferenceP` group, none of which are tracked through:

| kind | why |
|---|---|
| `Placeholder` | "does not have any associated parameter groups"; removed during expansion, "tracking through a `Placeholder` will never be needed" |
| `Girder` | support structure; no `length` nor `s_position` |
| `Feedback` | control element; no `length` nor `s_position` |
| `Fiducial` | fixes the reference orbit in floor coordinates |

If you'd rather have them on all 31 kinds, that's a one-line change to the selection.

## Also

Added an `(s:io.params)` anchor to the "User Settable (Input) and Dependent (Output) parameters" section so the new text can link to it. That section already documents this exact input-at-`BeginningEle` / output-elsewhere pattern for `FloorP`, which `TwissP` and `ParticleP` now follow.

## Checks

`sphinx-build` succeeds. The build emits the same 2 pre-existing footnote warnings as `main` (`footcite-mcmillan-multipoles`, `footcite-sagan-coupling`) and no new ones; all five referenced anchors (`s:beginningele`, `s:ref.params`, `s:io.params`, `s:twiss.params`, `s:particle.params`) resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
