### PR TITLE
Corrected `extra_dtime_ref` to `dtime_ref`.

### DIFF
--- a/source/parameters/patch.md
+++ b/source/parameters/patch.md
@@ -119,7 +119,7 @@ the exit coordinate system. In this case, the length will be equal to `z_offset`
 
 Note: To shift the reference energy, time, or species, use the 
 [ReferenceChangeP](#s:ref.change.params) parameter group.
-The `extra_dtime_ref` of the `ReferenceChageP` group can be used to set
-the change in reference time through a patch. The difference between using `extra_dtime_ref` and
-`length` is that the reference time change using `extra_dtime_ref` is independent of the reference 
+The `dtime_ref` of the `ReferenceChageP` group can be used to set
+the change in reference time through a patch. The difference between using `dtime_ref` and
+`length` is that the reference time change using `dtime_ref` is independent of the reference 
 velocity while with `length` there is a dependence upon the reference velocity. 

--- a/source/parameters/referencechange.md
+++ b/source/parameters/referencechange.md
@@ -21,9 +21,9 @@ Adjustments are only made if there are non-`null` parameters. Only one of `dE_re
 `dpc_ref`, `E_tot_ref`, and `pc_ref` may be present. 
 Similarly, only one of  `dtime_ref` and `time_ref` may be present.
 
-The `extra_dtime_ref` parameter in the above is ment as a correction to take into account
+The `dtime_ref` parameter in the above is ment as a correction to take into account
 for particle motion that is not straight or acceleration that is not linear in energy. For example,
-in a wiggler, `extra_dtime_ref` can be used to correct for the oscillatory nature of the
+in a wiggler, `dtime_ref` can be used to correct for the oscillatory nature of the
 particle trajectories.
-Since the PALS standard does not define how tracking is to be done, `extra_dtime_ref` and `dE_ref`
+Since the PALS standard does not define how tracking is to be done, `dtime_ref` and `dE_ref`
 must be calculated by the User.


### PR DESCRIPTION
Closes #249 
The name  `extra_dtime_ref` had not been converted to `dtime_ref` everywhere. This PR corrects that.