### PR TITLE
Route theme search box to Read the Docs server-side search

### DIFF
--- a/source/_static/rtd-search-override.js
+++ b/source/_static/rtd-search-override.js
@@ -1,0 +1,54 @@
+// Route the sphinx-book-theme search box to Read the Docs' server-side search.
+//
+// By default the theme's search box (sidebar + top-bar button) opens the
+// theme's built-in client-side search, which is page-granular and does not
+// find sub-section headings well. Read the Docs ships a much better
+// server-side search, but out of the box it is only reachable from the RTD
+// flyout menu and the "/" hotkey. This script makes the existing, prominent
+// search box open the RTD server-side search instead.
+//
+// RTD Addons only run on the hosted readthedocs.io build. On a local
+// `make html` build the RTD elements are absent, so we detect that and leave
+// the theme's built-in search untouched (no-op fallback).
+
+(function () {
+  "use strict";
+
+  // Selectors for the theme's search entry points (sidebar box + top-bar icon).
+  var SEARCH_TRIGGERS = ".search-button__button, [role='search'] input";
+
+  function rtdAddonsPresent() {
+    // On hosted readthedocs.io builds RTD injects the addons script at serve
+    // time (present from load) and the <readthedocs-*> elements at runtime.
+    // Local `make html` builds have neither, so search falls back to the theme.
+    return !!(
+      document.querySelector('script[src*="readthedocs-addons.js"]') ||
+      document.querySelector("readthedocs-search, readthedocs-flyout") ||
+      window.ReadTheDocsEventData
+    );
+  }
+
+  function openRtdSearch(event) {
+    // Only hijack when the RTD Addons search is actually available.
+    if (!rtdAddonsPresent()) {
+      return;
+    }
+    // Prevent the theme's own search modal from also opening.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    document.dispatchEvent(new CustomEvent("readthedocs-search-show"));
+  }
+
+  function wire() {
+    document.querySelectorAll(SEARCH_TRIGGERS).forEach(function (el) {
+      // Capture phase so we run before the theme's own click handler.
+      el.addEventListener("click", openRtdSearch, true);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", wire);
+  } else {
+    wire();
+  }
+})();

--- a/source/conf.py
+++ b/source/conf.py
@@ -36,4 +36,8 @@ html_theme_options = {
     "repository_url": "https://github.com/pals-project/pals",
     "use_repository_button": True,
 }
-## html_static_path = ['_static']
+html_static_path = ['_static']
+
+# Route the theme search box to Read the Docs' server-side search.
+# See _static/rtd-search-override.js for details.
+html_js_files = ['rtd-search-override.js']


### PR DESCRIPTION
## Problem

The theme's search box (left sidebar + top-bar button) opens sphinx-book-theme's built-in **client-side** search. That search is page-granular and doesn't surface sub-section headings well — e.g. searching `include` never gives a good hit for the **Including Other Files Within PALS files** section (it ranks the page under its H1, "Fundamental Structure", and can't link to the section anchor).

Read the Docs already builds a much better **server-side** search that finds that section by name with the correct anchor — but out of the box it's only reachable from the RTD flyout menu and the `/` hotkey, which is easy to miss. RTD does **not** automatically override a theme's search box.

## Fix

Per RTD's [documented integration](https://docs.readthedocs.com/platform/stable/addons.html), the desired search input should dispatch the `readthedocs-search-show` event. This PR adds `source/_static/rtd-search-override.js`, which intercepts clicks on the theme's existing search buttons (sidebar + top bar) and opens the RTD server-side search instead — so the prominent box becomes the good search, with no new box added.

- `source/_static/rtd-search-override.js` — the override (guards on RTD being present).
- `source/conf.py` — enable `html_static_path = ['_static']` and register the JS via `html_js_files`.

The script guards on RTD Addons being present, so **local `make html` builds fall back to the theme's built-in search** with no behavior change.

## Verification

Verified locally:
- Full docs build succeeds.
- The JS is copied to `_static/` and referenced on every page.
- Both theme search buttons match the script's selector.
- On a local build the guard leaves the theme search untouched (no regression).

RTD's addon JS only runs on hosted builds, so the click-to-server-side-search behavior can only be confirmed on the **PR preview build**: open the left-sidebar search on the preview and confirm it now finds sections like *Including Other Files…* by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
