### PR TITLE
MathJax fix: Escape underscores in `\text{}` arguments.

### DIFF
--- a/source/coordinates.md
+++ b/source/coordinates.md
@@ -502,10 +502,8 @@ particle's position {math}`{\bf q} = (x,y,z)` and momentum {math}`{\bf P} = (P_x
 when the coordinate frame is transformed from frame
 {math}`({\bf V}_{i-1}, {\bf W}_{i-1})` to frame {math}`({\bf V}_i, {\bf W}_i)` is
 \begin{align}
-{\bf q}_i &= {\bf S}_i^{-1} \, \left( {\bf q}_{i-1} - {\bf L}_i \right),
-\label{rwlr} \\
+{\bf q}_i &= {\bf S}_i^{-1} \, \left( {\bf q}_{i-1} - {\bf L}_i \right), \\
 {\bf P}_i &= {\bf S}_i^{-1} \, {\bf P}_{i-1}
-\label{pps}
 \end{align}
 
 Notice that since {math}`{\bf S}` (and {math}`{\bf W}`) is the product of orthogonal 
@@ -588,7 +586,7 @@ for `ref_tilt` versus everything else means that five transformations are needed
 branch frame to the element body frame (see Eq. Eq. [](#llee)). Symbolically:
 ```{math}
   \Lambda_s \longrightarrow \Lambda_\text{mid-arc} \longrightarrow
-  \Omega_\text{mid-chord} \longrightarrow \Omega_\text{offset} \longrightarrow \Omega_\text{tilt_ref}
+  \Omega_\text{mid-chord} \longrightarrow \Omega_\text{offset} \longrightarrow \Omega_\text{tilt\_ref}
   \longrightarrow E_\text{mid-arc} \longrightarrow E_s
 ```
 All transformations use Eqs. [](#wws).
@@ -609,11 +607,11 @@ For this transformation, {math}`\bf S` is the unit matrix and
 3. {math}`\Omega_\text{mid-chord} \longrightarrow \Omega_\text{offset}`: Element misalignment.
 This transformation uses Eqs. [](#swww2).
 
-4. {math}`\Omega_\text{offset} \longrightarrow \Omega_\text{tilt_ref}`: Rotation by `tilt_ref`
+4. {math}`\Omega_\text{offset} \longrightarrow \Omega_\text{tilt\_ref}`: Rotation by `tilt_ref`
 to get the coordinate system aligned with body coordinates. This transformation uses
 {math}`{\bf L} = 0` and {math}`{\bf S} = {\bf R}_z(\theta_{tr})`.
 
-5. {math}`\Omega_\text{tilt_ref} \longrightarrow E_\text{mid-arc}`: Translation to the mid point
+5. {math}`\Omega_\text{tilt\_ref} \longrightarrow E_\text{mid-arc}`: Translation to the mid point
 on the arc. For this transformation, {math}`\bf S` is the unit matrix and
 {math}`{\bf L} = \rho(\cos(\alpha_b/2) - 1) \, (1, 0, 0)` 
 

--- a/source/dispersion.md
+++ b/source/dispersion.md
@@ -29,7 +29,6 @@ some section of the lattice needs to be dispersion free, it is convenient to be 
 = \frac{d}{dp_z} \left( \frac{dy}{ds} \right)
 = \frac{d}{dp_z} \left( \frac{p_y}{1 + p_z} \right)
 = \frac{1}{1 + p_z} \, \eta_{py} - \frac{p_y}{(1 + p_z)^2}
-\label{dexds}
 \end{align}
 
 For a lattice branch which is [non-periodic](#s:lattice.construct), the dispersion of the {math}`z` phase space

--- a/source/parameters/patch.md
+++ b/source/parameters/patch.md
@@ -39,10 +39,10 @@ with
 
   {\bf L} &= 
     \begin{pmatrix} 
-      \text{x_offset} \\ \text{y_offset} \\ \text{z_offset} 
+      \text{x\_offset} \\ \text{y\_offset} \\ \text{z\_offset} 
     \end{pmatrix}
     \\
-  {\bf S} &= {\bf R}_{y} (\text{y_rot}) \; {\bf R}_{x} (\text{x_rot}) \; {\bf R}_{z} (\text{z_rot}) 
+  {\bf S} &= {\bf R}_{y} (\text{y\_rot}) \; {\bf R}_{x} (\text{x\_rot}) \; {\bf R}_{z} (\text{z\_rot}) 
 ```
 
 A straight line element like a `Drift` or a `Quadrupole` has the exit face parallel to the


### PR DESCRIPTION
Escape underscores in `\text{}` arguments.