### PR TITLE
Add a validated examples and unit-test corpus

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,25 @@
+# PALS Examples
+
+Example lattices for the Particle Accelerator Language Standard, as physics examples (suitable for integration tests) and small unit tests.
+
+## Layout
+
+| Path | Contents |
+| --- | --- |
+| `fodo.pals.yaml` | The introductory example: elements, a FODO cell, `inherit`, `repeat`, a lattice, and `use`. |
+| `machine/` | A small facility exercising the heavier constructs together: a multipass line, in-place element definitions, `inherit`, a repeated sub-line, a Fork into a dump branch, `include`, and two lattices sharing one line. Entry point: `machine.pals.yaml`. |
+| `modular_machine/` | A machine split over several files combined with `load`: the layout, one settings file, and a joiner that stacks them and adds a tweak of its own. Entry point: `joiner.pals.yaml`. |
+| `unit_tests/` | A corpus of small, single-feature lattices for unit tests, organized by feature. See `unit_tests/README.md`. |
+
+## Validation
+
+Every self-contained PALS file here must expand without problems.
+Two kinds of files are not self-contained and only carry meaning through the file that
+names them:
+
+- members of a `load` family (for example `modular_machine/settings.pals.yaml`)
+  are combined by their `joiner.pals.yaml`, which is the file to expand;
+- files spliced in by `include` (for example
+  `machine/subline_elements.subpals.yaml`) hold a facility-entry sequence, not
+  a full PALS document; per the standard's notation section they carry the
+  `.subpals.yaml` suffix.

--- a/examples/machine/machine.pals.yaml
+++ b/examples/machine/machine.pals.yaml
@@ -1,0 +1,76 @@
+# A small facility that exercises the heavier lattice constructs in one file:
+#
+# - a multipass injection line assembled from named and in-place elements
+# - `inherit` to derive one element (thingZ) from another (thingB)
+# - a sub-line (a_subline) spliced in three times with `repeat`
+# - a Fork into a dump line, creating the branch `this_dump`
+# - `include` to splice element definitions from another file into `facility`
+#   (subline_elements.subpals.yaml)
+# - two Lattices sharing the same line, selected as roots with `use`
+# - definitions appearing after their first use (generic_dump comes last)
+#
+# Adapted from the pals-cpp smoke-test lattice ex.pals.yaml.
+PALS:
+  facility:
+    - thingB:
+        kind: Sextupole
+        length: 2
+
+    - inj_line:
+        kind: BeamLine
+        multipass: true
+        length: 8.43           # the summed length of the line's elements
+        zero_point: Q1a
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: electron
+                E_tot_ref: 1.0e9
+          - thingZ:            # thingZ inherits its parameters from thingB
+              inherit: thingB
+          - Q1a:               # an element defined in place
+              kind: Quadrupole
+              length: 1.03
+              direction: -1
+          - a_subline:         # the sub-line, spliced in three times
+              repeat: 3
+          - to_dump:
+              kind: Fork
+              ForkP:
+                to_line: generic_dump
+                destination_element: dump_begin
+                new_branch: this_dump
+                propagate_reference: true
+
+    # Splice in the definitions of the elements a_subline uses.
+    - include: "subline_elements.subpals.yaml"
+
+    - a_subline:
+        kind: BeamLine
+        line:
+          - a
+          - b
+          - c
+
+    - lat1:
+        kind: Lattice
+        branches:
+          - inj_line
+    - lat2:
+        kind: Lattice
+        branches:
+          - inj_line
+
+    - use: lat2
+    - use: lat1
+
+    # The dump line the Fork feeds. Defined after the `use` entries: the order
+    # of facility entries does not matter for name resolution.
+    - generic_dump:
+        kind: BeamLine
+        line:
+          - dump_begin:
+              kind: Marker
+          - amarker:
+              kind: Marker

--- a/examples/machine/subline_elements.subpals.yaml
+++ b/examples/machine/subline_elements.subpals.yaml
@@ -1,0 +1,11 @@
+# Spliced into the `facility` list of machine.pals.yaml by its `include`
+# entry. An included file holds a YAML sequence of facility entries.
+- a:
+    kind: Drift
+    length: 1.0
+- b:
+    kind: Quadrupole
+    length: 0.5
+- c:
+    kind: Sextupole
+    length: 0.3

--- a/examples/modular_machine/joiner.pals.yaml
+++ b/examples/modular_machine/joiner.pals.yaml
@@ -1,0 +1,18 @@
+# A "joiner" file: the machine layout, then a settings file, then whatever
+# this file adds on top of both. `SELF` is where this file's own contents go --
+# here it is last, which is also where they would go had it been left out.
+#
+# Taken from the pals-cpp example lattice_files/load_joiner.pals.yaml.
+PALS:
+  notes:
+    - "Nominal configuration, with Q1b tweaked for the day's running."
+
+  load:
+    - layout.pals.yaml
+    - settings.pals.yaml
+    - SELF
+
+  facility:
+    - set:
+        parameter: Q1b>MagneticMultipoleP.Kn1
+        value: -0.36

--- a/examples/modular_machine/layout.pals.yaml
+++ b/examples/modular_machine/layout.pals.yaml
@@ -1,0 +1,35 @@
+# Layout half of the load example: what the machine is made of.
+# See joiner.pals.yaml.
+#
+# Taken from the pals-cpp example lattice_files/load_layout.pals.yaml.
+PALS:
+  version: "0.1"
+
+  notes:
+    - "Layout only. Magnet settings live in settings.pals.yaml."
+
+  facility:
+    - main:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - Q1a:
+              kind: Quadrupole
+              length: 0.5
+          - D1:
+              kind: Drift
+              length: 1.2
+          - Q1b:
+              kind: Quadrupole
+              length: 0.5
+
+    - lat1:
+        kind: Lattice
+        branches:
+          - main
+
+    - use: "lat1"

--- a/examples/modular_machine/settings.pals.yaml
+++ b/examples/modular_machine/settings.pals.yaml
@@ -1,0 +1,18 @@
+# Settings half of the load example: one configuration of the machine
+# layout.pals.yaml lays out. Several of these can share the one layout.
+#
+# Taken from the pals-cpp example lattice_files/load_settings.pals.yaml.
+PALS:
+  version: "0.1"
+
+  notes:
+    - "Settings for the nominal focusing configuration."
+
+  facility:
+    - set:
+        parameter: Q1a>MagneticMultipoleP.Kn1
+        value: 0.34
+
+    - set:
+        parameter: Q1b>MagneticMultipoleP.Kn1
+        value: -0.34

--- a/examples/unit_tests/README.md
+++ b/examples/unit_tests/README.md
@@ -1,0 +1,36 @@
+# PALS Unit-Test Lattices
+
+Small, single-feature PALS documents that can be used as unit tests.
+Each file demonstrates one behavior of the
+standard and states, in its header comment, what it shows and the test it
+comes from. Together they can serve as a conformance corpus for programs that
+read PALS: a reader should accept every file here, and where the header
+states derived values, expansion should reproduce them.
+
+Only lattices the tests treat as *valid* input were carried over; the
+deliberately malformed documents the tests use to probe error reporting were
+left behind.
+
+## Directories
+
+| Directory | Feature |
+| --- | --- |
+| `document/` | The PALS root node: documented root keys, prose (authors/notes/reminders), and extension labels with extension data. |
+| `elements/` | Element parameters and their dependent-parameter bookkeeping: reference propagation through a drift/quadrupole/bend line, RF voltage/gradient/active-length relations, bend geometry (angle, radius, chord, straight), the default bend actual field, integrated electric multipoles, and Twiss momentum dependence. |
+| `beamlines/` | Lattice branches and line construction: a branch taking its root BeamLine from its name, an explicit branch `inherit`, and `repeat` with nested sub-lines. |
+| `multipass/` | Multipass lines, flat and nested. |
+| `forks/` | Forks: the minimal form, named new branches, forking into an existing branch, destination bookkeeping (`forked_to` / `ForkFromP`), a forked-to line with its own BeginningEle, and a web of forks across two root branches. |
+| `expressions/` | Expressions: constants and variables (map and sequence forms), mathematical functions, `expr(...)`, `random_gauss()`, references to other elements' parameters, and species-name constants with `mass_of(...)`. |
+| `controllers/` | Controllers: ABSOLUTE (single, summed, pattern-matched targets), RELATIVE, a controller driving another controller's variable, and a controller reaching into a branch. |
+| `sets/` | `set` and the compact `sets` form: pattern-matched targets, `PARAMETER` and `SELF` in value expressions, and a set on a later-repeated definition. |
+| `loading/` | Families of files combined with `load`: SELF placement (explicit and implicit), nested and diamond-shaped load graphs, relative path resolution, merging of dictionary-valued root keys, version agreement, and `load` combined with `include`. |
+
+## Validation
+
+Every document outside `loading/` should expand with zero problems.
+In `loading/`, the file to expand is each family's
+`joiner.pals.yaml`; the families are deliberately minimal (mostly `notes`
+entries that make the combination order observable), so expanding a joiner
+combines its family cleanly and then reports only that there is no lattice to
+expand — except `loading/basic/`, whose joiner expands a complete lattice
+with zero problems.

--- a/examples/unit_tests/beamlines/branch_by_name.pals.yaml
+++ b/examples/unit_tests/beamlines/branch_by_name.pals.yaml
@@ -1,0 +1,27 @@
+# A Lattice branch with no `inherit` takes its root BeamLine from its own
+# name: the branch `ln` is built from the BeamLine `ln`. The branch entry can
+# still carry branch parameters of its own, here `periodic`.
+#
+# From pals-cpp tests/test_expansion.cpp
+# ("A branch with no inherit takes its root BeamLine from its name").
+PALS:
+  facility:
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1.0e9
+    - q:
+        kind: Quadrupole
+        length: 1
+    - ln:
+        kind: BeamLine
+        line:
+          - begin
+          - q
+    - machine:
+        kind: Lattice
+        branches:
+          - ln:
+              periodic: false
+    - use: "machine"

--- a/examples/unit_tests/beamlines/branch_inherit.pals.yaml
+++ b/examples/unit_tests/beamlines/branch_inherit.pals.yaml
@@ -1,0 +1,35 @@
+# An explicit branch `inherit` wins over the branch name: the branch is named
+# `alt`, but its contents come from the BeamLine `ring`. A BeamLine named
+# `alt` also exists and is not used.
+#
+# From pals-cpp tests/test_expansion.cpp
+# ("An explicit branch inherit wins over the branch name").
+PALS:
+  facility:
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1.0e9
+    - q_named:
+        kind: Quadrupole
+        length: 1
+    - s_wanted:
+        kind: Sextupole
+        length: 2
+    - alt:
+        kind: BeamLine
+        line:
+          - begin
+          - q_named
+    - ring:
+        kind: BeamLine
+        line:
+          - begin
+          - s_wanted
+    - machine:
+        kind: Lattice
+        branches:
+          - alt:
+              inherit: ring
+    - use: "machine"

--- a/examples/unit_tests/beamlines/repeat_nested.pals.yaml
+++ b/examples/unit_tests/beamlines/repeat_nested.pals.yaml
@@ -1,0 +1,39 @@
+# `repeat` expands the copies it splices: the cell appears three times, and
+# each copy's own sub-line (`inner`) is expanded within it.
+#
+# Adapted from pals-cpp tests/test_expansion.cpp
+# ("repeat expands the copies it splices"); a BeginningEle was added so the
+# reference parameters can be computed.
+PALS:
+  facility:
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1.0e9
+    - d1:
+        kind: Drift
+        length: 2.0
+    - q1:
+        kind: Quadrupole
+        length: 0.4
+    - inner:
+        kind: BeamLine
+        line:
+          - q1
+    - cell:
+        kind: BeamLine
+        line:
+          - d1
+          - inner
+    - main_line:
+        kind: BeamLine
+        line:
+          - begin
+          - cell:
+              repeat: 3
+    - lat1:
+        kind: Lattice
+        branches:
+          - main_line
+    - use: "lat1"

--- a/examples/unit_tests/controllers/absolute.pals.yaml
+++ b/examples/unit_tests/controllers/absolute.pals.yaml
@@ -1,0 +1,41 @@
+# An ABSOLUTE controller (the default control_type) driving every parameter
+# its pattern matches: Qa.* reaches Qa1 and Qa2 but not Qb1. The driven
+# parameters are completely determined by the controller expression.
+#
+# From pals-cpp tests/test_controllers.cpp
+# ("ABSOLUTE controllers drive the parameters they match").
+PALS:
+  facility:
+    - ps1:
+        kind: Controller
+        variables:
+          cur: 0.4
+        controls:
+          - parameter: Qa.*>MagneticMultipoleP.Kn1L
+            expression: 2 * cur
+    - lat1:
+        kind: Lattice
+        branches:
+          - main:
+              kind: BeamLine
+              line:
+                - begin:
+                    kind: BeginningEle
+                    ReferenceP:
+                      species_ref: "electron"
+                      E_tot_ref: 1.0e9
+                - Qa1:
+                    kind: Quadrupole
+                    MagneticMultipoleP:
+                      Kn1L: 0.11
+                - Qa2:
+                    kind: Quadrupole
+                    MagneticMultipoleP:
+                      Kn1L: 0.22
+                - Qb1:
+                    kind: Quadrupole
+                    MagneticMultipoleP:
+                      Kn1L: 0.33
+                - fin:
+                    kind: Marker
+    - use: "lat1"

--- a/examples/unit_tests/controllers/absolute_sum.pals.yaml
+++ b/examples/unit_tests/controllers/absolute_sum.pals.yaml
@@ -1,0 +1,41 @@
+# Several ABSOLUTE controllers on one parameter sum: a_kicker's Kn0 becomes
+# the sum of the two controller expressions, replacing the element's own
+# value. ps1 omits control_type, which defaults to ABSOLUTE.
+#
+# From pals-cpp tests/test_controllers.cpp
+# ("several ABSOLUTE controllers on one parameter sum").
+PALS:
+  facility:
+    - ps1:
+        kind: Controller
+        variables:
+          cur: 0.023
+        controls:
+          - parameter: a_kicker>MagneticMultipoleP.Kn0
+            expression: 0.075*sin(cur)
+    - ps2:
+        kind: Controller
+        control_type: ABSOLUTE
+        variables:
+          cur: 0.044
+        controls:
+          - parameter: a_kicker>MagneticMultipoleP.Kn0
+            expression: 0.123*cur
+    - lat1:
+        kind: Lattice
+        branches:
+          - main:
+              kind: BeamLine
+              line:
+                - begin:
+                    kind: BeginningEle
+                    ReferenceP:
+                      species_ref: "electron"
+                      E_tot_ref: 1.0e9
+                - a_kicker:
+                    kind: Kicker
+                    MagneticMultipoleP:
+                      Kn0: 9.9
+                - fin:
+                    kind: Marker
+    - use: "lat1"

--- a/examples/unit_tests/controllers/chained.pals.yaml
+++ b/examples/unit_tests/controllers/chained.pals.yaml
@@ -1,0 +1,40 @@
+# A control hierarchy: the controller `high` drives the variable `cur` of the
+# controller `low`, which in turn drives Q1. The order the controllers are
+# written in does not matter.
+#
+# From pals-cpp tests/test_controllers.cpp
+# ("a controller drives another controller's variable").
+PALS:
+  facility:
+    - low:
+        kind: Controller
+        variables:
+          cur: 0.1
+        controls:
+          - parameter: Q1>MagneticMultipoleP.Kn1L
+            expression: 10 * cur
+    - high:
+        kind: Controller
+        variables:
+          knob: 3
+        controls:
+          - parameter: low>cur
+            expression: knob / 4
+    - lat1:
+        kind: Lattice
+        branches:
+          - main:
+              kind: BeamLine
+              line:
+                - begin:
+                    kind: BeginningEle
+                    ReferenceP:
+                      species_ref: "electron"
+                      E_tot_ref: 1.0e9
+                - Q1:
+                    kind: Quadrupole
+                    MagneticMultipoleP:
+                      Kn1L: 0.0
+                - fin:
+                    kind: Marker
+    - use: "lat1"

--- a/examples/unit_tests/controllers/reach_into_branch.pals.yaml
+++ b/examples/unit_tests/controllers/reach_into_branch.pals.yaml
@@ -1,0 +1,37 @@
+# A controller reaching an element inside a branch, with the branch defined
+# in place under the Lattice and carrying a branch parameter (periodic). Also
+# a controller with a MetaP-free compact body: one variable, one control.
+#
+# From pals-cpp tests/test_controllers.cpp
+# ("a controller reaches an element in a branch named by its key").
+PALS:
+  facility:
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1.0e9
+    - q:
+        kind: Quadrupole
+        length: 1
+        MagneticMultipoleP:
+          Kn1: 256
+    - ln:
+        kind: BeamLine
+        line:
+          - begin
+          - q
+    - machine:
+        kind: Lattice
+        branches:
+          - ln:
+              periodic: false
+    - oo:
+        kind: Controller
+        control_type: ABSOLUTE
+        variables:
+          vv: 2
+        controls:
+          - parameter: q>MagneticMultipoleP.Kn1
+            expression: 4^vv
+    - use: "machine"

--- a/examples/unit_tests/controllers/relative.pals.yaml
+++ b/examples/unit_tests/controllers/relative.pals.yaml
@@ -1,0 +1,34 @@
+# A RELATIVE controller: a knob whose contribution is added on top of the
+# value the lattice gives the parameter, rather than replacing it. With the
+# knob at its written setting the lattice keeps S1's own Kn2L.
+#
+# From pals-cpp tests/test_controllers.cpp
+# ("a RELATIVE controller leaves the lattice alone").
+PALS:
+  facility:
+    - chrom_a:
+        kind: Controller
+        control_type: RELATIVE
+        variables:
+          command: 0.4
+        controls:
+          - parameter: S1>MagneticMultipoleP.Kn2L
+            expression: 5.62 * command + 0.02 * command^2
+    - lat1:
+        kind: Lattice
+        branches:
+          - main:
+              kind: BeamLine
+              line:
+                - begin:
+                    kind: BeginningEle
+                    ReferenceP:
+                      species_ref: "electron"
+                      E_tot_ref: 1.0e9
+                - S1:
+                    kind: Sextupole
+                    MagneticMultipoleP:
+                      Kn2L: 0.33
+                - fin:
+                    kind: Marker
+    - use: "lat1"

--- a/examples/unit_tests/document/extensions.pals.yaml
+++ b/examples/unit_tests/document/extensions.pals.yaml
@@ -1,0 +1,44 @@
+# Extension data: `extension_labels` registers extension names, prefixes, and
+# suffixes. Data under a registered label -- the element kind `Rotator`, the
+# groups `SciBmad_connect` and `tuning_local`, and the facility-level
+# `extension` entry -- is not part of the standard vocabulary and is passed
+# through unchecked.
+#
+# Adapted from pals-cpp tests/test_check.cpp
+# ("extension data is exempt from the spelling checks"); a line, lattice, and
+# BeginningEle were added so the document expands.
+PALS:
+  extension_labels:
+    names:
+      Rotator: a new kind of element
+    prefixes:
+      SciBmad_: for the SciBmad ecosystem
+    suffixes:
+      _local: site-local data
+  facility:
+    - r23:
+        kind: Rotator
+    - q1:
+        kind: Quadrupole
+        length: 1
+        SciBmad_connect:
+          BogusP: anything at all
+        tuning_local:
+          AlsoBogusP: and here too
+    - synch_connect:
+        extension: Cornell_CESR_Connect
+        NotAGroupP: alarm system stuff
+    - main:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - q1
+    - lat1:
+        kind: Lattice
+        branches:
+          - main
+    - use: "lat1"

--- a/examples/unit_tests/document/root_keys.pals.yaml
+++ b/examples/unit_tests/document/root_keys.pals.yaml
@@ -1,0 +1,41 @@
+# The documented keys of the PALS root node: version, authors, notes,
+# reminders, phase_space_coordinates, extension_labels, and facility. The
+# registered extension label `Bmad` lets the element q1 carry a `Bmad` block
+# of code-specific data.
+#
+# Adapted from pals-cpp tests/test_check.cpp
+# ("the documented keys of the PALS root node are not reported"); a line,
+# lattice, and BeginningEle were added so the document expands.
+PALS:
+  version: 1
+  authors:
+    - author:
+        name: Lastname, Firstname
+  notes:
+    - a note
+  reminders:
+    - a reminder
+  phase_space_coordinates: standard
+  extension_labels:
+    names:
+      Bmad: bmad-specific data
+  facility:
+    - q1:
+        kind: Quadrupole
+        length: 1
+        Bmad:
+          bmad_key: Quadrupole
+    - main:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - q1
+    - lat1:
+        kind: Lattice
+        branches:
+          - main
+    - use: "lat1"

--- a/examples/unit_tests/elements/bend_actual_field_default.pals.yaml
+++ b/examples/unit_tests/elements/bend_actual_field_default.pals.yaml
@@ -1,0 +1,27 @@
+# A bend given only its reference curvature g_ref. By default the actual
+# dipole field follows the reference field (Kn0_from_g_ref), so the expanded
+# element also carries the actual-field forms (Kn0, Bn0, ...) derived from
+# g_ref = 0.1.
+#
+# From pals-cpp tests/test_bookkeeper.cpp
+# ("Bookkeeper defaults the bend actual field from g_ref").
+PALS:
+  facility:
+    - test_line:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - bnd:
+              kind: Bend
+              length: 2.0
+              BendP:
+                g_ref: 0.1
+    - lat:
+        kind: Lattice
+        branches:
+          - test_line
+    - use: lat

--- a/examples/unit_tests/elements/bend_angle_radius.pals.yaml
+++ b/examples/unit_tests/elements/bend_angle_radius.pals.yaml
@@ -1,0 +1,28 @@
+# A bend given only its reference angle and radius. Those two are enough: the
+# arc length follows (1.0), and with it the chord, the rectangle length, and
+# the sagitta. An author may give any two of {curvature, a length, the angle}.
+#
+# From pals-cpp tests/test_bookkeeper.cpp
+# ("Bookkeeper derives the bend length from its angle and radius").
+PALS:
+  facility:
+    - test_line:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - bnd:
+              kind: Bend
+              BendP:
+                angle_ref: 0.2
+                radius_ref: 5.0
+          - after:
+              kind: Marker
+    - lat:
+        kind: Lattice
+        branches:
+          - test_line
+    - use: lat

--- a/examples/unit_tests/elements/bend_chord.pals.yaml
+++ b/examples/unit_tests/elements/bend_chord.pals.yaml
@@ -1,0 +1,25 @@
+# A bend given its curvature and its chord length. The bend angle and the arc
+# length follow from those two.
+#
+# From pals-cpp tests/test_bookkeeper.cpp
+# ("Bookkeeper derives the bend angle from its chord").
+PALS:
+  facility:
+    - test_line:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - bnd:
+              kind: Bend
+              BendP:
+                g_ref: 0.25
+                L_chord: 1.9
+    - lat:
+        kind: Lattice
+        branches:
+          - test_line
+    - use: lat

--- a/examples/unit_tests/elements/bend_straight.pals.yaml
+++ b/examples/unit_tests/elements/bend_straight.pals.yaml
@@ -1,0 +1,26 @@
+# A bend with no curvature given: a straight bend. Its arc, chord, and
+# rectangle lengths are all equal to the element length, and the sagitta is
+# zero. The edge angle e1 is independent of the (absent) bending.
+#
+# From pals-cpp tests/test_bookkeeper.cpp
+# ("Bookkeeper gives a straight bend three equal lengths").
+PALS:
+  facility:
+    - test_line:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - bnd:
+              kind: Bend
+              length: 0.8
+              BendP:
+                e1: 0.01
+    - lat:
+        kind: Lattice
+        branches:
+          - test_line
+    - use: lat

--- a/examples/unit_tests/elements/drift_quad_bend.pals.yaml
+++ b/examples/unit_tests/elements/drift_quad_bend.pals.yaml
@@ -1,0 +1,41 @@
+# One branch stepping through the common element kinds: a BeginningEle that
+# sets the reference particle, drifts, a quadrupole with a field strength, and
+# a bend given by its reference angle. Expansion derives the dependent
+# parameters: reference energy/momentum/time, s positions, floor coordinates,
+# the equivalent bend strength/length forms, and the integrated and normalized
+# multipole forms.
+#
+# From pals-cpp tests/test_bookkeeper.cpp (BOOKKEEPER_YAML).
+PALS:
+  facility:
+    - test_line:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - d1:
+              kind: Drift
+              length: 2.0
+          - q1:
+              kind: Quadrupole
+              length: 0.5
+              MagneticMultipoleP:
+                Bn1: 1.2
+          - b1:
+              kind: Bend
+              length: 1.5
+              BendP:
+                angle_ref: 0.15
+          - d2:
+              kind: Drift
+              length: 1.0
+          - end:
+              kind: Marker
+    - lat:
+        kind: Lattice
+        branches:
+          - test_line
+    - use: lat

--- a/examples/unit_tests/elements/electric_multipole.pals.yaml
+++ b/examples/unit_tests/elements/electric_multipole.pals.yaml
@@ -1,0 +1,25 @@
+# An electric multipole. Electric multipoles have no normalized form; only
+# length-integration ties En2 to En2L = length * En2 = 0.5 * 5 = 2.5.
+#
+# From pals-cpp tests/test_bookkeeper.cpp
+# ("Bookkeeper derives the integrated electric multipole").
+PALS:
+  facility:
+    - test_line:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - em:
+              kind: Sextupole
+              length: 0.5
+              ElectricMultipoleP:
+                En2: 5.0
+    - lat:
+        kind: Lattice
+        branches:
+          - test_line
+    - use: lat

--- a/examples/unit_tests/elements/rf_active_length.pals.yaml
+++ b/examples/unit_tests/elements/rf_active_length.pals.yaml
@@ -1,0 +1,26 @@
+# An RF cavity whose active length (0.25) differs from the element length
+# (0.4). The derived voltage follows the active length: 1.0e8 * 0.25 = 2.5e7.
+#
+# From pals-cpp tests/test_bookkeeper.cpp
+# ("Bookkeeper honors an explicit L_active for RF derivation").
+PALS:
+  facility:
+    - test_line:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - cav:
+              kind: RFCavity
+              length: 0.4
+              RFP:
+                gradient: 1.0e8
+                L_active: 0.25
+    - lat:
+        kind: Lattice
+        branches:
+          - test_line
+    - use: lat

--- a/examples/unit_tests/elements/rf_gradient.pals.yaml
+++ b/examples/unit_tests/elements/rf_gradient.pals.yaml
@@ -1,0 +1,25 @@
+# An RF cavity given only its gradient. The voltage follows from the active
+# length, which defaults to the element length: voltage = 1.0e8 * 0.4 = 4.0e7.
+#
+# From pals-cpp tests/test_bookkeeper.cpp
+# ("Bookkeeper derives RF voltage from gradient and active length").
+PALS:
+  facility:
+    - test_line:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - cav:
+              kind: RFCavity
+              length: 0.4
+              RFP:
+                gradient: 1.0e8
+    - lat:
+        kind: Lattice
+        branches:
+          - test_line
+    - use: lat

--- a/examples/unit_tests/elements/rf_voltage.pals.yaml
+++ b/examples/unit_tests/elements/rf_voltage.pals.yaml
@@ -1,0 +1,25 @@
+# An RF cavity given only its voltage. The gradient follows from the active
+# length, which defaults to the element length: gradient = 8.0e6 / 0.4 = 2.0e7.
+#
+# From pals-cpp tests/test_bookkeeper.cpp
+# ("Bookkeeper derives RF gradient from voltage and active length").
+PALS:
+  facility:
+    - test_line:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - cav:
+              kind: RFCavity
+              length: 0.4
+              RFP:
+                voltage: 8.0e6
+    - lat:
+        kind: Lattice
+        branches:
+          - test_line
+    - use: lat

--- a/examples/unit_tests/elements/rf_voltage_and_gradient.pals.yaml
+++ b/examples/unit_tests/elements/rf_voltage_and_gradient.pals.yaml
@@ -1,0 +1,26 @@
+# An RF cavity with both voltage and gradient set, and agreeing:
+# 2.0e7 * 0.4 = 8.0e6. Consistent redundant parameters are left untouched.
+#
+# From pals-cpp tests/test_bookkeeper.cpp
+# ("Bookkeeper accepts consistent RF voltage and gradient").
+PALS:
+  facility:
+    - test_line:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - cav:
+              kind: RFCavity
+              length: 0.4
+              RFP:
+                gradient: 2.0e7
+                voltage: 8.0e6
+    - lat:
+        kind: Lattice
+        branches:
+          - test_line
+    - use: lat

--- a/examples/unit_tests/elements/twiss_momentum_dependence.pals.yaml
+++ b/examples/unit_tests/elements/twiss_momentum_dependence.pals.yaml
@@ -1,0 +1,31 @@
+# A BeginningEle carrying Twiss parameters, including their momentum
+# dependence: the d..._dpz derivatives of the a/b-mode Twiss functions and of
+# the x/y dispersion.
+#
+# From pals-cpp tests/test_check.cpp
+# ("the momentum dependence of the Twiss parameters is accepted").
+PALS:
+  facility:
+    - main:
+        kind: BeamLine
+        line:
+          - beg:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+              TwissP:
+                beta_a: 12.5
+                dbeta_a_dpz: 1.5
+                dalpha_a_dpz: 0.1
+                dbeta_b_dpz: -2.0
+                dalpha_b_dpz: 0.2
+                deta_x_dpz: 0.3
+                detap_x_dpz: 0.4
+                deta_y_dpz: 0.5
+                detap_y_dpz: 0.6
+    - lat1:
+        kind: Lattice
+        branches:
+          - main
+    - use: "lat1"

--- a/examples/unit_tests/expressions/constants_variables.pals.yaml
+++ b/examples/unit_tests/expressions/constants_variables.pals.yaml
@@ -1,0 +1,34 @@
+# Constants and variables in their compact map form, used in element
+# parameters. Constants may build on physical constants (r_electron) and on
+# each other; variables may reference constants; an element length may be an
+# expression over both.
+#
+# Adapted from pals-cpp tests/test_expressions.cpp
+# ("parse_and_expand_PALS resolves map-form constants/variables"); a
+# BeginningEle was added so the reference parameters can be computed.
+PALS:
+  facility:
+    - constants:
+        a_const: 0.3 * r_electron
+        b_const: 0.45
+    - variables:
+        a_var: a_const^2
+        b_var: 0.37 * atan2(0.1, 0.2)
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1.0e9
+    - d1:
+        kind: Drift
+        length: a_const + b_const
+    - main_line:
+        kind: BeamLine
+        line:
+          - begin
+          - d1
+    - lat1:
+        kind: Lattice
+        branches:
+          - main_line
+    - use: "lat1"

--- a/examples/unit_tests/expressions/element_parameter_reference.pals.yaml
+++ b/examples/unit_tests/expressions/element_parameter_reference.pals.yaml
@@ -1,0 +1,30 @@
+# An expression that reaches into another element: DH1A's edge field integral
+# is defined in terms of thingB's integrated sextupole strength, using the
+# ele>Group.parameter syntax.
+#
+# From pals-cpp tests/test_expressions.cpp
+# ("parse_and_expand_PALS resolves element-parameter references").
+PALS:
+  facility:
+    - thingB:
+        kind: Sextupole
+        length: 0.3
+        MagneticMultipoleP:
+          Kn2L: 0.1
+    - DH1A:
+        kind: Bend
+        length: 0.2
+        ReferenceP:
+          species_ref: proton
+          E_tot_ref: 1.0e9
+        BendP:
+          edge2_int: 0.02 * thingB>MagneticMultipoleP.Kn2L
+    - main_line:
+        kind: BeamLine
+        line:
+          - DH1A
+    - lat1:
+        kind: Lattice
+        branches:
+          - main_line
+    - use: "lat1"

--- a/examples/unit_tests/expressions/inline_expressions.pals.yaml
+++ b/examples/unit_tests/expressions/inline_expressions.pals.yaml
@@ -1,0 +1,37 @@
+# Expressions in element parameters: constants and variables in their
+# sequence form, mathematical functions (log, abs), the explicit expr(...)
+# marker, a random draw (random_gauss), and a constant defined from a species
+# mass (mass_of).
+#
+# Adapted from pals-cpp tests/test_expressions.cpp
+# ("parse_and_expand_PALS evaluates expressions in the expanded tree"); a
+# BeginningEle was added so the reference parameters can be computed.
+PALS:
+  facility:
+    - variables:
+        - a_var: 3.75e7 / c_light^2
+        - b_var: -0.34
+    - m_e:
+        kind: constant
+        value: mass_of("electron")
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1.0e9
+    - cleo:
+        kind: Solenoid
+        length: 0.1*log(abs(b_var))
+        MagneticMultipoleP:
+          Kn1: expr(3.74 * a_var)
+          Kn2: 0.01 + 0.003*random_gauss()
+    - main_line:
+        kind: BeamLine
+        line:
+          - begin
+          - cleo
+    - lat1:
+        kind: Lattice
+        branches:
+          - main_line
+    - use: "lat1"

--- a/examples/unit_tests/expressions/species_constant.pals.yaml
+++ b/examples/unit_tests/expressions/species_constant.pals.yaml
@@ -1,0 +1,26 @@
+# A constant holding a species name ("#3He"), used both as a species
+# reference and inside mass_of(...) expressions.
+#
+# From pals-cpp tests/test_expressions.cpp
+# ("parse_and_expand_PALS resolves a species-name constant").
+PALS:
+  facility:
+    - constants:
+        species: "#3He"
+        b_const: 0.45 * mass_of(species)
+    - DH1A:
+        kind: Bend
+        ReferenceP:
+          species_ref: species
+          E_tot_ref: 1.0e10
+        BendP:
+          h1: 1.1 * mass_of(species)
+    - main_line:
+        kind: BeamLine
+        line:
+          - DH1A
+    - lat1:
+        kind: Lattice
+        branches:
+          - main_line
+    - use: "lat1"

--- a/examples/unit_tests/forks/fork_destinations.pals.yaml
+++ b/examples/unit_tests/forks/fork_destinations.pals.yaml
@@ -1,0 +1,51 @@
+# Three forks and their destinations: f1 forks to a named destination element
+# in a new named branch, f2 takes every default, and f3 forks with
+# `new_branch: null` into the branch f1 created. Expansion records each
+# connection: a Fork names its destination in ForkP.forked_to, and a
+# destination element lists its incoming Forks in ForkFromP.
+#
+# From pals-cpp tests/test_expansion.cpp
+# ("a Fork names its destination in ForkP.forked_to").
+PALS:
+  facility:
+    - m0:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: proton
+          E_tot_ref: 1.0e9
+    - dump_begin:
+        kind: Marker
+    - alt_begin:
+        kind: Marker
+    - dump_line:
+        kind: BeamLine
+        line:
+          - dump_begin
+    - alt_line:
+        kind: BeamLine
+        line:
+          - alt_begin
+    - ring:
+        kind: BeamLine
+        line:
+          - m0
+          - f1:
+              kind: Fork
+              ForkP:
+                to_line: dump_line
+                destination_element: dump_begin
+                new_branch: proton_dump
+          - f2:
+              kind: Fork
+              ForkP:
+                to_line: alt_line
+          - f3:
+              kind: Fork
+              ForkP:
+                to_line: proton_dump
+                new_branch: null
+    - lat1:
+        kind: Lattice
+        branches:
+          - ring
+    - use: "lat1"

--- a/examples/unit_tests/forks/fork_existing_branch.pals.yaml
+++ b/examples/unit_tests/forks/fork_existing_branch.pals.yaml
@@ -1,0 +1,37 @@
+# `new_branch: null` forks into an already-existing branch instead of
+# creating one: `other` is a branch of the lattice in its own right, with its
+# own BeginningEle, and the Fork in `ring` connects to it.
+#
+# From pals-cpp tests/test_expansion.cpp
+# ("new_branch: null forks into an existing branch, creating none").
+PALS:
+  facility:
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: proton
+          E_tot_ref: 1.0e9
+    - eb:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: electron
+          E_tot_ref: 5.0e8
+    - other:
+        kind: BeamLine
+        line:
+          - eb
+    - ring:
+        kind: BeamLine
+        line:
+          - begin
+          - f1:
+              kind: Fork
+              ForkP:
+                to_line: other
+                new_branch: null
+    - lat1:
+        kind: Lattice
+        branches:
+          - other
+          - ring
+    - use: "lat1"

--- a/examples/unit_tests/forks/fork_minimal.pals.yaml
+++ b/examples/unit_tests/forks/fork_minimal.pals.yaml
@@ -1,0 +1,32 @@
+# The minimal Fork: only `to_line` is given. The destination element defaults
+# to the first element of the target line, and the new branch takes the target
+# line's name.
+#
+# From pals-cpp tests/test_expansion.cpp
+# ("a Fork needs only to_line; destination_element and new_branch default").
+PALS:
+  facility:
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: proton
+          E_tot_ref: 1.0e9
+    - dump_begin:
+        kind: Marker
+    - dump_line:
+        kind: BeamLine
+        line:
+          - dump_begin
+    - ring:
+        kind: BeamLine
+        line:
+          - begin
+          - f1:
+              kind: Fork
+              ForkP:
+                to_line: dump_line
+    - lat1:
+        kind: Lattice
+        branches:
+          - ring
+    - use: "lat1"

--- a/examples/unit_tests/forks/fork_new_branch.pals.yaml
+++ b/examples/unit_tests/forks/fork_new_branch.pals.yaml
@@ -1,0 +1,34 @@
+# A Fork that names its new branch (`extraction`). The reference particle and
+# the floor position at the fork point propagate into the branch it creates.
+#
+# From pals-cpp tests/test_expansion.cpp
+# ("a Fork propagates reference and floor into its new branch").
+PALS:
+  facility:
+    - begin:
+        kind: BeginningEle
+        FloorP:
+          x: 1.5
+        ReferenceP:
+          species_ref: proton
+          E_tot_ref: 1.0e9
+    - m1:
+        kind: Marker
+    - ext_line:
+        kind: BeamLine
+        line:
+          - m1
+    - ring:
+        kind: BeamLine
+        line:
+          - begin
+          - f1:
+              kind: Fork
+              ForkP:
+                to_line: ext_line
+                new_branch: extraction
+    - lat1:
+        kind: Lattice
+        branches:
+          - ring
+    - use: "lat1"

--- a/examples/unit_tests/forks/fork_to_dump_line.pals.yaml
+++ b/examples/unit_tests/forks/fork_to_dump_line.pals.yaml
@@ -1,0 +1,40 @@
+# A ring with a fork to a dump line whose first element is a BeginningEle of
+# its own. Each branch numbers its elements independently: element_index
+# restarts at one in the forked-to branch.
+#
+# From pals-cpp tests/test_bookkeeper.cpp
+# ("element_index restarts at one in each branch").
+PALS:
+  facility:
+    - dump_begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1.0e9
+    - dump_end:
+        kind: Marker
+    - dump_line:
+        kind: BeamLine
+        line:
+          - dump_begin
+          - dump_end
+    - ring:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - drift1:
+              kind: Drift
+              length: 1.0
+          - f1:
+              kind: Fork
+              ForkP:
+                to_line: dump_line
+    - lat1:
+        kind: Lattice
+        branches:
+          - ring
+    - use: "lat1"

--- a/examples/unit_tests/forks/fork_web.pals.yaml
+++ b/examples/unit_tests/forks/fork_web.pals.yaml
@@ -1,0 +1,66 @@
+# A web of forks: two root branches, forks out of both, a fork inside a
+# forked-to line, and two forks naming the same line (`a_line`). A fork whose
+# new_branch is unset instantiates its own destination branch from the named
+# line, so a_line (and the b_line its fork feeds) appears once per fork that
+# names it.
+#
+# From pals-cpp tests/test_expansion.cpp
+# ("a destination_pointer survives expression substitution intact").
+PALS:
+  facility:
+    - begin1:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1e7
+    - m:
+        kind: Marker
+    - dft:
+        kind: Drift
+        length: 2
+    - pad1:
+        kind: Drift
+        length: 1
+    - pad2:
+        kind: Drift
+        length: 1
+    - pad3:
+        kind: Drift
+        length: 1
+    - a_fork:
+        kind: Fork
+        ForkP:
+          to_line: a_line
+    - b_fork:
+        kind: Fork
+        ForkP:
+          to_line: b_line
+    - c_fork:
+        kind: Fork
+        ForkP:
+          to_line: c_line
+    - a_back_fork:
+        kind: Fork
+        ForkP:
+          to_line: a_line
+    - zero_line:
+        kind: BeamLine
+        line: [begin1, dft, a_fork]
+    - one_line:
+        kind: BeamLine
+        line: [begin1, dft, c_fork]
+    - a_line:
+        kind: BeamLine
+        line: [m, dft, b_fork]
+    - b_line:
+        kind: BeamLine
+        line: [m, dft]
+    - c_line:
+        kind: BeamLine
+        line: [m, dft, a_back_fork]
+    - root_lat:
+        kind: Lattice
+        branches:
+          - zero_line
+          - one_line
+    - use: "root_lat"

--- a/examples/unit_tests/loading/basic/joiner.pals.yaml
+++ b/examples/unit_tests/loading/basic/joiner.pals.yaml
@@ -1,0 +1,10 @@
+# The basic load family: a joiner pulling in a layout file and a settings
+# file, with SELF marking where the joiner's own contents go.
+# From pals-cpp tests/lattices/load_basic.
+PALS:
+  notes:
+    - "joiner note"
+  load:
+    - layout.pals.yaml
+    - settings.pals.yaml
+    - SELF

--- a/examples/unit_tests/loading/basic/layout.pals.yaml
+++ b/examples/unit_tests/loading/basic/layout.pals.yaml
@@ -1,0 +1,23 @@
+# Layout member of the basic load family: the machine, its lattice, and the
+# use entry. See joiner.pals.yaml.
+# From pals-cpp tests/lattices/load_basic.
+PALS:
+  notes:
+    - "layout note"
+  facility:
+    - main:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - Q1a:
+              kind: Quadrupole
+              length: 0.5
+    - lat1:
+        kind: Lattice
+        branches:
+          - main
+    - use: "lat1"

--- a/examples/unit_tests/loading/basic/settings.pals.yaml
+++ b/examples/unit_tests/loading/basic/settings.pals.yaml
@@ -1,0 +1,10 @@
+# Settings member of the basic load family: one set entry writing a
+# quadrupole strength of the layout. See joiner.pals.yaml.
+# From pals-cpp tests/lattices/load_basic.
+PALS:
+  notes:
+    - "settings note"
+  facility:
+    - set:
+        parameter: Q1a>MagneticMultipoleP.Kn1
+        value: 0.34

--- a/examples/unit_tests/loading/diamond/joiner.pals.yaml
+++ b/examples/unit_tests/loading/diamond/joiner.pals.yaml
@@ -1,0 +1,7 @@
+# A diamond of loads: left and right both load shared.pals.yaml, which is
+# included in the combined document only once.
+# From pals-cpp tests/lattices/load_diamond.
+PALS:
+  load:
+    - left.pals.yaml
+    - right.pals.yaml

--- a/examples/unit_tests/loading/diamond/left.pals.yaml
+++ b/examples/unit_tests/loading/diamond/left.pals.yaml
@@ -1,0 +1,5 @@
+# Left side of the diamond; loads shared.pals.yaml.
+# From pals-cpp tests/lattices/load_diamond.
+PALS:
+  load:
+    - shared.pals.yaml

--- a/examples/unit_tests/loading/diamond/right.pals.yaml
+++ b/examples/unit_tests/loading/diamond/right.pals.yaml
@@ -1,0 +1,5 @@
+# Right side of the diamond; also loads shared.pals.yaml.
+# From pals-cpp tests/lattices/load_diamond.
+PALS:
+  load:
+    - shared.pals.yaml

--- a/examples/unit_tests/loading/diamond/shared.pals.yaml
+++ b/examples/unit_tests/loading/diamond/shared.pals.yaml
@@ -1,0 +1,5 @@
+# Loaded by both left.pals.yaml and right.pals.yaml; appears once.
+# From pals-cpp tests/lattices/load_diamond.
+PALS:
+  notes:
+    - "shared"

--- a/examples/unit_tests/loading/extension_labels/a.pals.yaml
+++ b/examples/unit_tests/loading/extension_labels/a.pals.yaml
@@ -1,0 +1,6 @@
+# Loaded by joiner.pals.yaml; contributes its own extension labels.
+# From pals-cpp tests/lattices/load_dict.
+PALS:
+  extension_labels:
+    from_a: "A"
+    shared: "same"

--- a/examples/unit_tests/loading/extension_labels/joiner.pals.yaml
+++ b/examples/unit_tests/loading/extension_labels/joiner.pals.yaml
@@ -1,0 +1,10 @@
+# Dictionary-valued root keys merge across loaded files: extension_labels
+# from this file and from a.pals.yaml combine; an identical value on the
+# shared key is not a clash.
+# From pals-cpp tests/lattices/load_dict.
+PALS:
+  extension_labels:
+    shared: "same"
+    from_joiner: "J"
+  load:
+    - a.pals.yaml

--- a/examples/unit_tests/loading/implicit_self/a.pals.yaml
+++ b/examples/unit_tests/loading/implicit_self/a.pals.yaml
@@ -1,0 +1,5 @@
+# Loaded by joiner.pals.yaml.
+# From pals-cpp tests/lattices/load_noself.
+PALS:
+  notes:
+    - "a"

--- a/examples/unit_tests/loading/implicit_self/joiner.pals.yaml
+++ b/examples/unit_tests/loading/implicit_self/joiner.pals.yaml
@@ -1,0 +1,8 @@
+# A load list without SELF: the joiner's own contents implicitly go last,
+# after everything loaded.
+# From pals-cpp tests/lattices/load_noself.
+PALS:
+  notes:
+    - "joiner"
+  load:
+    - a.pals.yaml

--- a/examples/unit_tests/loading/include/joiner.pals.yaml
+++ b/examples/unit_tests/loading/include/joiner.pals.yaml
@@ -1,0 +1,10 @@
+# load and include together: the loaded layout uses include to splice
+# facility entries from a sibling directory, and this joiner adds an
+# element of its own on top.
+# From pals-cpp tests/lattices/load_include.
+PALS:
+  load:
+    - sub/layout.pals.yaml
+  facility:
+    - m2:
+        kind: Marker

--- a/examples/unit_tests/loading/include/parts/extra.subpals.yaml
+++ b/examples/unit_tests/loading/include/parts/extra.subpals.yaml
@@ -1,0 +1,4 @@
+# Facility entries spliced into sub/layout.pals.yaml by its include entry.
+# From pals-cpp tests/lattices/load_include.
+- extra_ele:
+    kind: Marker

--- a/examples/unit_tests/loading/include/sub/layout.pals.yaml
+++ b/examples/unit_tests/loading/include/sub/layout.pals.yaml
@@ -1,0 +1,8 @@
+# Loaded by ../joiner.pals.yaml; includes ../parts/extra.subpals.yaml
+# relative to itself.
+# From pals-cpp tests/lattices/load_include.
+PALS:
+  facility:
+    - m1:
+        kind: Marker
+    - include: "../parts/extra.subpals.yaml"

--- a/examples/unit_tests/loading/nested/a.pals.yaml
+++ b/examples/unit_tests/loading/nested/a.pals.yaml
@@ -1,0 +1,5 @@
+# Loaded by inner.pals.yaml.
+# From pals-cpp tests/lattices/load_nested.
+PALS:
+  notes:
+    - "a"

--- a/examples/unit_tests/loading/nested/inner.pals.yaml
+++ b/examples/unit_tests/loading/nested/inner.pals.yaml
@@ -1,0 +1,9 @@
+# Loaded by joiner.pals.yaml; loads a.pals.yaml itself, with its own SELF
+# placed first.
+# From pals-cpp tests/lattices/load_nested.
+PALS:
+  notes:
+    - "inner"
+  load:
+    - SELF
+    - a.pals.yaml

--- a/examples/unit_tests/loading/nested/joiner.pals.yaml
+++ b/examples/unit_tests/loading/nested/joiner.pals.yaml
@@ -1,0 +1,8 @@
+# Nested loads: this joiner loads inner.pals.yaml, which loads a file of
+# its own. The notes record the resulting order.
+# From pals-cpp tests/lattices/load_nested.
+PALS:
+  notes:
+    - "joiner"
+  load:
+    - inner.pals.yaml

--- a/examples/unit_tests/loading/relative_paths/joiner.pals.yaml
+++ b/examples/unit_tests/loading/relative_paths/joiner.pals.yaml
@@ -1,0 +1,6 @@
+# Load paths are resolved relative to the file naming them: this joiner
+# loads sub/inner.pals.yaml, which reaches back up with ../top.pals.yaml.
+# From pals-cpp tests/lattices/load_relative.
+PALS:
+  load:
+    - sub/inner.pals.yaml

--- a/examples/unit_tests/loading/relative_paths/sub/inner.pals.yaml
+++ b/examples/unit_tests/loading/relative_paths/sub/inner.pals.yaml
@@ -1,0 +1,8 @@
+# Loaded by ../joiner.pals.yaml; loads ../top.pals.yaml relative to itself.
+# From pals-cpp tests/lattices/load_relative.
+PALS:
+  notes:
+    - "inner"
+  load:
+    - ../top.pals.yaml
+    - SELF

--- a/examples/unit_tests/loading/relative_paths/top.pals.yaml
+++ b/examples/unit_tests/loading/relative_paths/top.pals.yaml
@@ -1,0 +1,5 @@
+# Loaded by sub/inner.pals.yaml as ../top.pals.yaml.
+# From pals-cpp tests/lattices/load_relative.
+PALS:
+  notes:
+    - "top"

--- a/examples/unit_tests/loading/self_position/a.pals.yaml
+++ b/examples/unit_tests/loading/self_position/a.pals.yaml
@@ -1,0 +1,5 @@
+# Loaded first by joiner.pals.yaml.
+# From pals-cpp tests/lattices/load_self.
+PALS:
+  notes:
+    - "a"

--- a/examples/unit_tests/loading/self_position/b.pals.yaml
+++ b/examples/unit_tests/loading/self_position/b.pals.yaml
@@ -1,0 +1,5 @@
+# Loaded last by joiner.pals.yaml, after its SELF.
+# From pals-cpp tests/lattices/load_self.
+PALS:
+  notes:
+    - "b"

--- a/examples/unit_tests/loading/self_position/joiner.pals.yaml
+++ b/examples/unit_tests/loading/self_position/joiner.pals.yaml
@@ -1,0 +1,10 @@
+# SELF placed between two loaded files: the combined document holds a, then
+# this file's own contents, then b. The notes record the order.
+# From pals-cpp tests/lattices/load_self.
+PALS:
+  notes:
+    - "joiner"
+  load:
+    - a.pals.yaml
+    - SELF
+    - b.pals.yaml

--- a/examples/unit_tests/loading/version_match/a.pals.yaml
+++ b/examples/unit_tests/loading/version_match/a.pals.yaml
@@ -1,0 +1,4 @@
+# Loaded by joiner.pals.yaml; states the same version.
+# From pals-cpp tests/lattices/load_version_same.
+PALS:
+  version: "1.0"

--- a/examples/unit_tests/loading/version_match/joiner.pals.yaml
+++ b/examples/unit_tests/loading/version_match/joiner.pals.yaml
@@ -1,0 +1,6 @@
+# Files combined by load must agree on the PALS version when both state one.
+# From pals-cpp tests/lattices/load_version_same.
+PALS:
+  version: "1.0"
+  load:
+    - a.pals.yaml

--- a/examples/unit_tests/multipass/multipass.pals.yaml
+++ b/examples/unit_tests/multipass/multipass.pals.yaml
@@ -1,0 +1,40 @@
+# A multipass line: `linac` is marked `multipass: true` and appears twice in
+# the ring, so its elements are shared between the two passes and each
+# instance is numbered with a multipass_index.
+#
+# Adapted from pals-cpp tests/test_multipass.cpp
+# ("Multipass sub-lines are numbered with a multipass_index"); a BeginningEle
+# was added so the reference parameters can be computed.
+PALS:
+  facility:
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1.0e9
+    - cavA:
+        kind: Quadrupole
+    - mark:
+        kind: Marker
+    - inj:
+        kind: BeamLine
+        line:
+          - mark
+    - linac:
+        kind: BeamLine
+        multipass: true
+        line:
+          - cavA
+          - cavA
+    - ring:
+        kind: BeamLine
+        line:
+          - begin
+          - inj
+          - linac
+          - linac
+    - lat1:
+        kind: Lattice
+        branches:
+          - ring
+    - use: lat1

--- a/examples/unit_tests/multipass/multipass_nested.pals.yaml
+++ b/examples/unit_tests/multipass/multipass_nested.pals.yaml
@@ -1,0 +1,38 @@
+# Nested multipass lines: `inner` is a multipass line inside the multipass
+# line `outer`. For the elements of `inner`, the nearest enclosing multipass
+# line wins the numbering.
+#
+# Adapted from pals-cpp tests/test_multipass.cpp
+# ("Nested multipass lines: the nearest multipass line wins"); a BeginningEle
+# was added so the reference parameters can be computed.
+PALS:
+  facility:
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1.0e9
+    - x:
+        kind: Marker
+    - y:
+        kind: Marker
+    - inner:
+        kind: BeamLine
+        multipass: true
+        line:
+          - y
+          - y
+    - outer:
+        kind: BeamLine
+        multipass: true
+        line:
+          - begin
+          - x
+          - inner
+          - inner
+          - x
+    - lat1:
+        kind: Lattice
+        branches:
+          - outer
+    - use: lat1

--- a/examples/unit_tests/sets/set_pattern.pals.yaml
+++ b/examples/unit_tests/sets/set_pattern.pals.yaml
@@ -1,0 +1,40 @@
+# A `set` entry writing every element its pattern matches: B1.* reaches B1a
+# and B1b but not Q1. In the value expression, `PARAMETER` is the current
+# value of the parameter being written and `SELF` reaches the rest of the
+# element being written.
+#
+# From pals-cpp tests/test_sets.cpp
+# ("a set writes every element its pattern matches").
+PALS:
+  facility:
+    - main:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - B1a:
+              kind: Bend
+              length: 1.0
+              BendP:
+                e1: 0.1
+                g_ref: 0.02
+          - B1b:
+              kind: Bend
+              length: 1.0
+              BendP:
+                e1: 0.3
+                g_ref: 0.02
+          - Q1:
+              kind: Quadrupole
+              length: 0.5
+    - set:
+        parameter: B1.*>BendP.e1
+        value: 2*PARAMETER + atan(SELF.BendP.g_ref)
+    - lat1:
+        kind: Lattice
+        branches:
+          - main
+    - use: "lat1"

--- a/examples/unit_tests/sets/set_single_definition.pals.yaml
+++ b/examples/unit_tests/sets/set_single_definition.pals.yaml
@@ -1,0 +1,30 @@
+# A `set` targeting an element that is later repeated: the set writes the one
+# definition, and all three expanded copies inherit the new value.
+#
+# From pals-cpp tests/test_sets.cpp
+# ("without expand_lattice a set writes the single definition").
+PALS:
+  facility:
+    - q1:
+        kind: Quadrupole
+        length: 0.5
+        MagneticMultipoleP:
+          Kn1L: 0.375
+    - set:
+        parameter: q1>MagneticMultipoleP.Kn1L
+        value: PARAMETER * 2
+    - main:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - q1:
+              repeat: 3
+    - lat1:
+        kind: Lattice
+        branches:
+          - main
+    - use: "lat1"

--- a/examples/unit_tests/sets/sets_compact.pals.yaml
+++ b/examples/unit_tests/sets/sets_compact.pals.yaml
@@ -1,0 +1,30 @@
+# The compact `sets` form: a sequence of parameter/value pairs, each written
+# as one mapping entry. Values may be expressions.
+#
+# From pals-cpp tests/test_sets.cpp ("the compact sets form writes each pair").
+PALS:
+  facility:
+    - Q1:
+        kind: Quadrupole
+        length: 0.5
+    - D1:
+        kind: Drift
+        length: 1.0
+    - sets:
+        - Q1>MagneticMultipoleP.Kn1L: 0.25
+        - D1>length: 2 * 1.5
+    - main:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - Q1
+          - D1
+    - lat1:
+        kind: Lattice
+        branches:
+          - main
+    - use: "lat1"


### PR DESCRIPTION
Collect the valid PALS lattices from the [pals-cpp](https://github.com/pals-project/pals-cpp/tree/8d5cb48789fe86805d331e8ac67700953a83141f/tests) examples and unit tests into `examples/`:
two demonstrative machines (`machine/`, `modular_machine/`) and a feature-organized unit-test corpus (`unit_tests/`) covering the document root, element bookkeeping, beamlines, multipass, forks, expressions, controllers, sets, and `load`/`include` file families. Each file states in its header what it demonstrates and the `pals-cpp` test it comes from.

Every self-contained file expands without problems with `pals-cpp`'s `parse_and_expand_PALS`, members of load families are expanded through their `joiner.pals.yaml`.
