### PR TITLE
Simplify Author List

### DIFF
--- a/examples/unit_tests/document/root_keys.pals.yaml
+++ b/examples/unit_tests/document/root_keys.pals.yaml
@@ -9,8 +9,8 @@
 PALS:
   version: 1
   authors:
-    - author:
-        name: Lastname, Firstname
+    - name: Lastname, Firstname
+    - name: Lastname2, Firstname2
   notes:
     - a note
   reminders:

--- a/source/fundamentals.md
+++ b/source/fundamentals.md
@@ -36,13 +36,14 @@ PALS:
       my_extension: "See the PALS extensions chapter"
 
   authors:
-    - author:
-        name: Lastname, Firstname
-        orcid: AAAA-BBBB-CCCC-DDDD
-        affiliation: Affiliation Long Name
-        email: lastname@laboratory.gov
-    - author:
-        ...
+    - name: Lastname, Firstname
+      orcid: AAAA-BBBB-CCCC-DDDD
+      affiliation: Affiliation Long Name
+      email: lastname@laboratory.gov
+    - name: Lastname2, Firstname2
+      orcid: EEEE-FFFF-GGGG-HHHH
+      affiliation: Affiliation2 Long Name
+      email: lastname2@university.edu
 
   facility:
     - ...  # lattice elements, beamlines, lattices, parameter set commands, etc.


### PR DESCRIPTION
The current author list is overly complicated by adding an additional empty dictionary.
Simplify to list of dict.

Seen while implementing in Python as extra complication that can be avoided for the schema.